### PR TITLE
udigest v0.2

### DIFF
--- a/.github/changelog.sh
+++ b/.github/changelog.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+m_branch=m;
+changelog_file=CHANGELOG.md;
+
+# fetch master since we might be in a shallow clone
+git fetch origin "$m_branch:$m_branch" --depth=1
+
+changed=0;
+for log in */"$changelog_file"; do
+    dir=$(dirname "$log");
+    # check if version changed
+    if git diff "$m_branch" -- "$dir/Cargo.toml" | grep -q "^-version = "; then
+        # check if changelog updated
+        if git diff --exit-code --no-patch "$m_branch" -- "$log"; then
+            echo "$dir version changed, but $log is not updated"
+            changed=1;
+        fi
+    fi
+done
+
+exit "$changed";

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,3 +67,9 @@ jobs:
         cache-on-failure: "true"
     - name: Run clippy
       run: cargo clippy --all-features -- -D clippy::all
+  check-changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Check changelogs
+      run: ./.github/changelog.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,4 +66,4 @@ jobs:
       with:
         cache-on-failure: "true"
     - name: Run clippy
-      run: cargo clippy -- -D clippy::all
+      run: cargo clippy --all-features -- -D clippy::all

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,29 +9,31 @@ env:
   CARGO_NET_GIT_FETCH_WITH_CLI: true
 
 jobs:
-  build-and-test:
+  check-and-test:
     strategy:
       matrix:
-        features: ["", "derive", "derive,alloc", "derive,std"]
+        features: ["", "derive", "derive,alloc", "derive,std", "digest", "digest,std"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: "true"
-    - name: Build
-      run: cargo build -p udigest --features "${{ matrix.features }}"
+    - name: Check
+      run: cargo check -p udigest --features "${{ matrix.features }}"
     - name: Run tests
       run: cargo test -p udigest --lib --tests --features "${{ matrix.features }}"
-  doctest:
+  test-all-features:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: "true"
-    - name: Doctests
-      run: cargo test --doc --all-features
+    - name: Check
+      run: cargo check -p udigest --all-features
+    - name: Run tests
+      run: cargo test -p udigest --all-features
   run-examples:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,6 +53,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -61,6 +71,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "libc"
@@ -98,6 +117,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
 name = "syn"
 version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,9 +153,11 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 name = "udigest"
 version = "0.1.0"
 dependencies = [
+ "blake2",
  "digest",
  "hex",
  "sha2",
+ "sha3",
  "udigest-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "udigest"
-version = "0.1.0"
+version = "0.2.0-rc1"
 dependencies = [
  "blake2",
  "digest",

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,14 @@
+.PHONY: docs docs-open
+
+docs:
+	RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --no-deps --all-features
+
+docs-open:
+	RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --no-deps --all-features --open
+
+docs-private:
+	RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --no-deps --all-features --document-private-items
+
 readme:
 	cargo readme -i src/lib.rs -r udigest/ -t ../docs/readme.tpl \
 		| perl -ne 's/\[(.+?)\]\((?!https).+?\)/\1/g; print;' \

--- a/README.md
+++ b/README.md
@@ -17,34 +17,33 @@ data can be anything that implements `Digestable` trait:
 
 The trait is intentionally not implemented for certain types:
 
-* `HashMap`, `HashSet` as they can not be traversed in determenistic order
-* `usize`, `isize` as their byte size varies on differnet platforms
+* `HashMap`, `HashSet` as they can not be traversed in deterministic order
+* `usize`, `isize` as their byte size varies on different platforms
 
 The `Digestable` trait can be implemented for the struct using a macro:
 ```rust
-use udigest::{Tag, udigest};
-use sha2::Sha256;
-
 #[derive(udigest::Digestable)]
 struct Person {
     name: String,
     job_title: String,
 }
-let alice = &Person {
+let alice = Person {
     name: "Alice".into(),
     job_title: "cryptographer".into(),
 };
 
-let tag = Tag::<Sha256>::new("udigest.example");
-let hash = udigest(tag, &alice);
+let hash = udigest::hash::<sha2::Sha256, _>(&alice);
 ```
 
 The crate intentionally does not try to follow any existing standards for unambiguous
-encoding. The format for encoding was desingned specifically for `udigest` to provide
+encoding. The format for encoding was designed specifically for `udigest` to provide
 a better usage experience in Rust. The details of encoding format can be found in
 `encoding` module.
 
 ### Features
+* `digest` enables support of hash functions that implement `digest` traits \
+   If feature is not enabled, the crate is still usable via `Digestable` trait that
+   generically implements unambiguous encoding
 * `std` implements `Digestable` trait for types in standard library
 * `alloc` implements `Digestable` trait for type in `alloc` crate
 * `derive` enables `Digestable` proc macro

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ let alice = Person {
     job_title: "cryptographer".into(),
 };
 
-let hash = udigest::hash::<sha2::Sha256, _>(&alice);
+let hash = udigest::hash::<sha2::Sha256>(&alice);
 ```
 
 The crate intentionally does not try to follow any existing standards for unambiguous

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ a better usage experience in Rust. The details of encoding format can be found i
 * `digest` enables support of hash functions that implement `digest` traits \
    If feature is not enabled, the crate is still usable via `Digestable` trait that
    generically implements unambiguous encoding
+* `inline-struct` is required to use `inline_struct!` macro
 * `std` implements `Digestable` trait for types in standard library
 * `alloc` implements `Digestable` trait for type in `alloc` crate
 * `derive` enables `Digestable` proc macro

--- a/cspell.yml
+++ b/cspell.yml
@@ -1,0 +1,10 @@
+words:
+- digestable
+- udigest
+- VecDeque
+- bytestring
+- bytestrings
+- biglen
+- sublist
+- docsrs
+- concated

--- a/cspell.yml
+++ b/cspell.yml
@@ -8,3 +8,4 @@ words:
 - sublist
 - docsrs
 - concated
+- inlines

--- a/udigest/CHANGELOG.md
+++ b/udigest/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Add support of all hash functions compatible with `digest` crate:
   hash functions with fixed output, with extendable output, and with
   variable output [#4]
+* Add `udigest::inline_struct!` macro [#4]
+* fix: handle cases when `EncodeValue` is dropped without being used
 
 [#4]: https://github.com/dfns/udigest/pull/4
 

--- a/udigest/CHANGELOG.md
+++ b/udigest/CHANGELOG.md
@@ -1,0 +1,12 @@
+## v0.2.0
+* Breaking change: remove `udigest::Tag` [#4]
+* Breaking change: rename `udigest::udigest` function to `udigest::hash` [#4]
+* Add support of all hash functions compatible with `digest` crate:
+  hash functions with fixed output, with extendable output, and with
+  variable output [#4]
+
+[#4]: https://github.com/dfns/udigest/pull/4
+
+## v0.1.0
+
+The first release!

--- a/udigest/Cargo.toml
+++ b/udigest/Cargo.toml
@@ -11,22 +11,30 @@ readme = "../README.md"
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-digest = { version = "0.10", default-features = false }
+digest = { version = "0.10", default-features = false, optional = true }
 
 udigest-derive = { version = "0.1", optional = true }
 
 [dev-dependencies]
-sha2 = "0.10"
 hex = "0.4"
 
+sha2 = "0.10"
+sha3 = "0.10"
+blake2 = "0.10"
+
 [features]
+default = ["digest", "std"]
+
 std = ["alloc"]
 alloc = []
 derive = ["dep:udigest-derive"]
+
+digest = ["dep:digest"]
 
 [[test]]
 name = "derive"

--- a/udigest/Cargo.toml
+++ b/udigest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udigest"
-version = "0.1.0"
+version = "0.2.0-rc1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Unambiguously digest structured data"

--- a/udigest/Cargo.toml
+++ b/udigest/Cargo.toml
@@ -28,22 +28,27 @@ sha3 = "0.10"
 blake2 = "0.10"
 
 [features]
-default = ["digest", "std"]
+default = ["digest", "std", "inline-struct"]
 
 std = ["alloc"]
 alloc = []
 derive = ["dep:udigest-derive"]
 
 digest = ["dep:digest"]
+inline-struct = []
 
 [[test]]
 name = "derive"
 required-features = ["std", "derive", "digest"]
 
-[[example]]
-name = "derivation"
-required-features = ["std", "derive", "digest"]
-
 [[test]]
 name = "deterministic_hash"
 required-features = ["derive", "digest"]
+
+[[test]]
+name = "inline_struct"
+required-features = ["derive", "inline-struct"]
+
+[[example]]
+name = "derivation"
+required-features = ["std", "derive", "digest"]

--- a/udigest/Cargo.toml
+++ b/udigest/Cargo.toml
@@ -38,8 +38,12 @@ digest = ["dep:digest"]
 
 [[test]]
 name = "derive"
-required-features = ["std", "derive"]
+required-features = ["std", "derive", "digest"]
 
 [[example]]
 name = "derivation"
-required-features = ["std", "derive"]
+required-features = ["std", "derive", "digest"]
+
+[[test]]
+name = "deterministic_hash"
+required-features = ["derive", "digest"]

--- a/udigest/examples/derivation.rs
+++ b/udigest/examples/derivation.rs
@@ -12,6 +12,6 @@ fn main() {
         job_title: "cryptographer".into(),
     };
 
-    let hash = udigest::hash::<sha2::Sha256, _>(&person);
+    let hash = udigest::hash::<sha2::Sha256>(&person);
     println!("{}", hex::encode(hash));
 }

--- a/udigest/examples/derivation.rs
+++ b/udigest/examples/derivation.rs
@@ -1,6 +1,3 @@
-use sha2::Sha256;
-use udigest::udigest;
-
 #[derive(udigest::Digestable)]
 #[udigest(tag = "udigest.example.Person.v1")]
 struct Person {
@@ -15,7 +12,6 @@ fn main() {
         job_title: "cryptographer".into(),
     };
 
-    let tag = udigest::Tag::<Sha256>::new("udigest.example");
-    let hash = udigest(tag, &person);
+    let hash = udigest::hash::<sha2::Sha256, _>(&person);
     println!("{}", hex::encode(hash));
 }

--- a/udigest/src/inline_struct.rs
+++ b/udigest/src/inline_struct.rs
@@ -40,6 +40,7 @@ impl InlineStruct<'static> {
     /// Creates inline struct with no fields
     ///
     /// Normally, you don't need to use it directly. Use [`inline_struct!`] macro instead.
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {
             fields_list: Nil,

--- a/udigest/src/inline_struct.rs
+++ b/udigest/src/inline_struct.rs
@@ -1,0 +1,195 @@
+//! Digestable inline structs
+//!
+//! If you find yourself in situation in which you have to define a struct just
+//! to use it only once for `udigest` hashing, [`inline_struct!`] macro can be
+//! used instead:
+//!
+//! ```rust
+//! let hash = udigest::hash::<sha2::Sha256, _>(&udigest::inline_struct!({
+//!     name: "Alice",
+//!     age: 24_u32,
+//! }));
+//! ```
+//!
+//! Which will produce identical hash as below:
+//!
+//! ```rust
+//! #[derive(udigest::Digestable)]
+//! struct Person {
+//!     name: &'static str,
+//!     age: u32,
+//! }
+//!
+//! let hash = udigest::hash::<sha2::Sha256, _>(&Person {
+//!     name: "Alice",
+//!     age: 24,
+//! });
+//! ```
+//!
+//! See [`inline_struct!`] macro for more examples.
+
+/// Inline structure
+///
+/// Normally, you don't need to use it directly. Use [`inline_struct!`] macro instead.
+pub struct InlineStruct<'a, F: FieldsList + 'a = Nil> {
+    fields_list: F,
+    tag: Option<&'a [u8]>,
+}
+
+impl InlineStruct<'static> {
+    /// Creates inline struct with no fields
+    ///
+    /// Normally, you don't need to use it directly. Use [`inline_struct!`] macro instead.
+    pub fn new() -> Self {
+        Self {
+            fields_list: Nil,
+            tag: None,
+        }
+    }
+}
+
+impl<'a, F: FieldsList + 'a> InlineStruct<'a, F> {
+    /// Adds field to the struct
+    ///
+    /// Normally, you don't need to use it directly. Use [`inline_struct!`] macro instead.
+    pub fn add_field<V>(
+        self,
+        field_name: &'a str,
+        field_value: &'a V,
+    ) -> InlineStruct<'a, impl FieldsList + 'a>
+    where
+        F: 'a,
+        V: crate::Digestable,
+    {
+        InlineStruct {
+            fields_list: cons(field_name, field_value, self.fields_list),
+            tag: self.tag,
+        }
+    }
+
+    /// Sets domain-separation tag
+    ///
+    /// Normally, you don't need to use it directly. Use [`inline_struct!`] macro instead.
+    pub fn set_tag<T: ?Sized + AsRef<[u8]>>(mut self, tag: &'a T) -> Self {
+        self.tag = Some(tag.as_ref());
+        self
+    }
+}
+
+impl<'a, F: FieldsList + 'a> crate::Digestable for InlineStruct<'a, F> {
+    fn unambiguously_encode<B: crate::Buffer>(&self, encoder: crate::encoding::EncodeValue<B>) {
+        let mut struct_encode = encoder.encode_struct();
+        if let Some(tag) = self.tag {
+            struct_encode.set_tag(tag);
+        }
+        self.fields_list.encode(&mut struct_encode);
+    }
+}
+
+/// Creates digestable inline struct
+///
+/// Macro creates "inlined" (anonymous) struct instance containing specified fields and their
+/// values. The inlined struct implements [`Digestable` trait](crate::Digestable), and therefore
+/// can be unambiguously hashed, for instance, using [`udigest::hash`](crate::hash). It helps
+/// reducing amount of code when otherwise you'd have to define a separate struct which would
+/// only be used one.
+///
+/// ## Usage
+/// The code snippet below inlines `struct Person { name: &str, age: u32 }`.
+/// ```rust
+/// let hash = udigest::hash::<sha2::Sha256, _>(&udigest::inline_struct!({
+///     name: "Alice",
+///     age: 24_u32,
+/// }));
+/// ```
+///
+/// You may add a domain separation tag:
+/// ```rust
+/// let hash = udigest::hash::<sha2::Sha256, _>(
+///     &udigest::inline_struct!("some tag" {
+///         name: "Alice",
+///         age: 24_u32,
+///     })
+/// );
+/// ```
+///
+/// Several structs may be embedded in each other:
+/// ```rust
+/// let hash = udigest::hash::<sha2::Sha256, _>(&udigest::inline_struct!({
+///     name: "Alice",
+///     age: 24_u32,
+///     preferences: udigest::inline_struct!({
+///         display_email: false,
+///         receive_newsletter: false,
+///     }),
+/// }));
+/// ```
+#[macro_export]
+macro_rules! inline_struct {
+    ({$($field_name:ident: $field_value:expr),*$(,)?}) => {{
+        $crate::inline_struct::InlineStruct::new()
+            $(.add_field(stringify!($field_name), &$field_value))*
+    }};
+    ($tag:tt {$($field_name:ident: $field_value:expr),*$(,)?}) => {{
+        $crate::inline_struct::InlineStruct::new()
+            .set_tag($tag)
+            $(.add_field(stringify!($field_name), &$field_value))*
+
+    }};
+}
+
+pub use crate::inline_struct;
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// List of fields in inline struct
+///
+/// Normally, you don't need to use it directly. Use [`inline_struct!`] macro instead.
+pub trait FieldsList: sealed::Sealed {
+    /// Encodes all fields in order from the first to last
+    fn encode<B: crate::Buffer>(&self, encoder: &mut crate::encoding::EncodeStruct<B>);
+}
+
+/// Empty list of fields
+///
+/// Normally, you don't need to use it directly. Use [`inline_struct!`] macro instead.
+pub struct Nil;
+impl sealed::Sealed for Nil {}
+impl FieldsList for Nil {
+    fn encode<B: crate::Buffer>(&self, _encoder: &mut crate::encoding::EncodeStruct<B>) {
+        // Empty list - do nothing
+    }
+}
+
+fn cons<'a, V, T>(field_name: &'a str, field_value: &'a V, tail: T) -> impl FieldsList + 'a
+where
+    V: crate::Digestable,
+    T: FieldsList + 'a,
+{
+    struct Cons<'a, V, T: 'a> {
+        field_name: &'a str,
+        field_value: &'a V,
+        tail: T,
+    }
+
+    impl<'a, V, T: 'a> sealed::Sealed for Cons<'a, V, T> {}
+
+    impl<'a, V: crate::Digestable, T: FieldsList + 'a> FieldsList for Cons<'a, V, T> {
+        fn encode<B: crate::Buffer>(&self, encoder: &mut crate::encoding::EncodeStruct<B>) {
+            // Since we store fields from last to first, we need to encode the tail first
+            // to reverse order of fields
+            self.tail.encode(encoder);
+
+            let value_encoder = encoder.add_field(self.field_name);
+            self.field_value.unambiguously_encode(value_encoder);
+        }
+    }
+
+    Cons {
+        field_name,
+        field_value,
+        tail,
+    }
+}

--- a/udigest/src/inline_struct.rs
+++ b/udigest/src/inline_struct.rs
@@ -5,7 +5,7 @@
 //! used instead:
 //!
 //! ```rust
-//! let hash = udigest::hash::<sha2::Sha256, _>(&udigest::inline_struct!({
+//! let hash = udigest::hash::<sha2::Sha256>(&udigest::inline_struct!({
 //!     name: "Alice",
 //!     age: 24_u32,
 //! }));
@@ -20,7 +20,7 @@
 //!     age: u32,
 //! }
 //!
-//! let hash = udigest::hash::<sha2::Sha256, _>(&Person {
+//! let hash = udigest::hash::<sha2::Sha256>(&Person {
 //!     name: "Alice",
 //!     age: 24,
 //! });
@@ -98,7 +98,7 @@ impl<'a, F: FieldsList + 'a> crate::Digestable for InlineStruct<'a, F> {
 /// ## Usage
 /// The code snippet below inlines `struct Person { name: &str, age: u32 }`.
 /// ```rust
-/// let hash = udigest::hash::<sha2::Sha256, _>(&udigest::inline_struct!({
+/// let hash = udigest::hash::<sha2::Sha256>(&udigest::inline_struct!({
 ///     name: "Alice",
 ///     age: 24_u32,
 /// }));
@@ -106,7 +106,7 @@ impl<'a, F: FieldsList + 'a> crate::Digestable for InlineStruct<'a, F> {
 ///
 /// You may add a domain separation tag:
 /// ```rust
-/// let hash = udigest::hash::<sha2::Sha256, _>(
+/// let hash = udigest::hash::<sha2::Sha256>(
 ///     &udigest::inline_struct!("some tag" {
 ///         name: "Alice",
 ///         age: 24_u32,
@@ -116,7 +116,7 @@ impl<'a, F: FieldsList + 'a> crate::Digestable for InlineStruct<'a, F> {
 ///
 /// Several structs may be embedded in each other:
 /// ```rust
-/// let hash = udigest::hash::<sha2::Sha256, _>(&udigest::inline_struct!({
+/// let hash = udigest::hash::<sha2::Sha256>(&udigest::inline_struct!({
 ///     name: "Alice",
 ///     age: 24_u32,
 ///     preferences: udigest::inline_struct!({

--- a/udigest/src/lib.rs
+++ b/udigest/src/lib.rs
@@ -99,8 +99,8 @@ pub use encoding::Buffer;
 ///   )
 ///   ```
 ///   `person_a` and `person_b` have exactly the same hash as they have the same bytes
-///   representation. For that reason, make sure that the [Tag] is unique per application.
-///   You may also specify a tag per data type using `#[udigest(tag = "...")]` attribute.
+///   representation. If you need to distinguish them, you can specify a domain-separation
+///   tag using `#[udigest(tag = "...")]` attribute.
 ///
 /// ### Container attributes
 /// * `#[udigest(tag = "...")]` \

--- a/udigest/src/lib.rs
+++ b/udigest/src/lib.rs
@@ -44,6 +44,7 @@
 //! * `digest` enables support of hash functions that implement [`digest`] traits \
 //!    If feature is not enabled, the crate is still usable via [`Digestable`] trait that
 //!    generically implements unambiguous encoding
+//! * `inline-struct` is required to use [`inline_struct!`] macro
 //! * `std` implements `Digestable` trait for types in standard library
 //! * `alloc` implements `Digestable` trait for type in `alloc` crate
 //! * `derive` enables `Digestable` proc macro

--- a/udigest/src/lib.rs
+++ b/udigest/src/lib.rs
@@ -201,6 +201,8 @@ pub use encoding::Buffer;
 pub use udigest_derive::Digestable;
 
 pub mod encoding;
+#[cfg(feature = "inline-struct")]
+pub mod inline_struct;
 
 /// Digests a structured `value` using fixed-output hash function (like sha2-256)
 #[cfg(feature = "digest")]
@@ -322,6 +324,12 @@ macro_rules! digestable_integers {
 }
 
 digestable_integers!(i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
+
+impl Digestable for bool {
+    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+        u8::from(*self).unambiguously_encode(encoder)
+    }
+}
 
 impl Digestable for char {
     fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {

--- a/udigest/src/lib.rs
+++ b/udigest/src/lib.rs
@@ -32,7 +32,7 @@
 //!     job_title: "cryptographer".into(),
 //! };
 //!
-//! let hash = udigest::hash::<sha2::Sha256, _>(&alice);
+//! let hash = udigest::hash::<sha2::Sha256>(&alice);
 //! ```
 //!
 //! The crate intentionally does not try to follow any existing standards for unambiguous
@@ -95,8 +95,8 @@ pub use encoding::Buffer;
 ///   let person_b = PersonB{ name: b"Alice".to_vec() };
 ///   
 ///   assert_eq!(
-///       udigest::hash::<sha2::Sha256, _>(&person_a),
-///       udigest::hash::<sha2::Sha256, _>(&person_b),
+///       udigest::hash::<sha2::Sha256>(&person_a),
+///       udigest::hash::<sha2::Sha256>(&person_b),
 ///   )
 ///   ```
 ///   `person_a` and `person_b` have exactly the same hash as they have the same bytes
@@ -207,7 +207,7 @@ pub mod inline_struct;
 
 /// Digests a structured `value` using fixed-output hash function (like sha2-256)
 #[cfg(feature = "digest")]
-pub fn hash<D: digest::Digest, T: Digestable>(value: &T) -> digest::Output<D> {
+pub fn hash<D: digest::Digest>(value: &impl Digestable) -> digest::Output<D> {
     let mut hash = encoding::BufferDigest(D::new());
     value.unambiguously_encode(encoding::EncodeValue::new(&mut hash));
     hash.0.finalize()
@@ -230,9 +230,8 @@ pub fn hash_iter<D: digest::Digest>(
 
 /// Digests a structured `value` using extendable-output hash function (like shake-256)
 #[cfg(feature = "digest")]
-pub fn hash_xof<D, T>(value: &T) -> D::Reader
+pub fn hash_xof<D>(value: &impl Digestable) -> D::Reader
 where
-    T: Digestable,
     D: Default + digest::Update + digest::ExtendableOutput,
 {
     let mut hash = encoding::BufferUpdate(D::default());
@@ -258,9 +257,8 @@ where
 
 /// Digests a structured `value` using variable-output hash function (like blake2b)
 #[cfg(feature = "digest")]
-pub fn hash_vof<D, T>(value: &T, out: &mut [u8]) -> Result<(), digest::InvalidOutputSize>
+pub fn hash_vof<D>(value: &impl Digestable, out: &mut [u8]) -> Result<(), digest::InvalidOutputSize>
 where
-    T: Digestable,
     D: digest::VariableOutput + digest::Update,
 {
     let mut hash = encoding::BufferUpdate(D::new(out.len())?);

--- a/udigest/tests/derive.rs
+++ b/udigest/tests/derive.rs
@@ -38,9 +38,9 @@ pub enum EnumExample {
         something_else: SomeValue,
     },
     Variant2(String, #[udigest(as_bytes)] Vec<u8>, #[udigest(skip)] Empty),
-    Vartiant3 {},
+    Variant3 {},
     Variant4(),
-    Vartiant5,
+    Variant5,
 }
 
 #[derive(udigest::Digestable)]

--- a/udigest/tests/deterministic_hash.rs
+++ b/udigest/tests/deterministic_hash.rs
@@ -19,13 +19,13 @@ const BOB: Person = Person {
 
 #[test]
 fn sha2_256() {
-    let alice_hash = udigest::hash::<sha2::Sha256, _>(&ALICE);
+    let alice_hash = udigest::hash::<sha2::Sha256>(&ALICE);
     assert_eq!(
         hex::encode(alice_hash.as_slice()),
         "99e258d6a6ccc430a50dcbf4e9c8cfb59ad0b94b96b83f0182a9a68eb1c5438f",
     );
 
-    let bob_hash = udigest::hash::<sha2::Sha256, _>(&BOB);
+    let bob_hash = udigest::hash::<sha2::Sha256>(&BOB);
     assert_eq!(
         hex::encode(bob_hash.as_slice()),
         "28474b5dec79b222b74badc2d78f9f81c0fbfd1ee04a134947cd07f44237ade3",
@@ -37,7 +37,7 @@ fn shake256() {
     use digest::XofReader;
 
     let mut hash = [0u8; 123];
-    let mut alice_hash_reader = udigest::hash_xof::<sha3::Shake256, _>(&ALICE);
+    let mut alice_hash_reader = udigest::hash_xof::<sha3::Shake256>(&ALICE);
     alice_hash_reader.read(&mut hash);
     assert_eq!(
         hex::encode(&hash),
@@ -47,7 +47,7 @@ fn shake256() {
         5fae7f8e4958ceb38962fc8e6fc56e32bef4e88f64bc8a88f88a"
     );
 
-    let mut bob_hash_reader = udigest::hash_xof::<sha3::Shake256, _>(&BOB);
+    let mut bob_hash_reader = udigest::hash_xof::<sha3::Shake256>(&BOB);
     bob_hash_reader.read(&mut hash);
     assert_eq!(
         hex::encode(&hash),
@@ -62,14 +62,14 @@ fn shake256() {
 fn blake2b() {
     let mut out = [0u8; 63];
 
-    udigest::hash_vof::<blake2::Blake2bVar, _>(&ALICE, &mut out).unwrap();
+    udigest::hash_vof::<blake2::Blake2bVar>(&ALICE, &mut out).unwrap();
     assert_eq!(
         hex::encode(&out),
         "91d1ce144fd46ed5400895c8db5f2b39c95870020c6627af034a9fa09c2f2cc3\
         f4c8c7d4e8d38ff16e4f54360b4387c0439cf30c51c21c78f904cda9205023"
     );
 
-    udigest::hash_vof::<blake2::Blake2bVar, _>(&BOB, &mut out).unwrap();
+    udigest::hash_vof::<blake2::Blake2bVar>(&BOB, &mut out).unwrap();
     assert_eq!(
         hex::encode(&out),
         "2f916c687c82c0f37d31df061c0453e98d0655e1877d4a55ec1507514822a2c4\

--- a/udigest/tests/deterministic_hash.rs
+++ b/udigest/tests/deterministic_hash.rs
@@ -1,0 +1,78 @@
+#[derive(udigest::Digestable)]
+pub struct Person {
+    name: &'static str,
+    age: u16,
+    job_title: &'static str,
+}
+
+const ALICE: Person = Person {
+    name: "Alice",
+    age: 24,
+    job_title: "cryptographer",
+};
+
+const BOB: Person = Person {
+    name: "Bob",
+    age: 25,
+    job_title: "research engineer",
+};
+
+#[test]
+fn sha2_256() {
+    let alice_hash = udigest::hash::<sha2::Sha256, _>(&ALICE);
+    assert_eq!(
+        hex::encode(alice_hash.as_slice()),
+        "99e258d6a6ccc430a50dcbf4e9c8cfb59ad0b94b96b83f0182a9a68eb1c5438f",
+    );
+
+    let bob_hash = udigest::hash::<sha2::Sha256, _>(&BOB);
+    assert_eq!(
+        hex::encode(bob_hash.as_slice()),
+        "28474b5dec79b222b74badc2d78f9f81c0fbfd1ee04a134947cd07f44237ade3",
+    );
+}
+
+#[test]
+fn shake256() {
+    use digest::XofReader;
+
+    let mut hash = [0u8; 123];
+    let mut alice_hash_reader = udigest::hash_xof::<sha3::Shake256, _>(&ALICE);
+    alice_hash_reader.read(&mut hash);
+    assert_eq!(
+        hex::encode(&hash),
+        "54809cf7b06438f9508785fb5e46bdfd7714b39b026e86fa7cc8a8442ae10bd5\
+        49baeced19ff0642b042ae4e92636536baec5748dad99e71fc53a4361734973ae\
+        2c4f1547305a76addd5b6076509ddbf91bd5beb71ba09598e265704d1e9a1c0c3\
+        5fae7f8e4958ceb38962fc8e6fc56e32bef4e88f64bc8a88f88a"
+    );
+
+    let mut bob_hash_reader = udigest::hash_xof::<sha3::Shake256, _>(&BOB);
+    bob_hash_reader.read(&mut hash);
+    assert_eq!(
+        hex::encode(&hash),
+        "f68ca9eeb7e09657fc54a5cbbd50acdd6d9fccd29ec1a3eb460b673ea59d64a9\
+        b2ec8be97c7d7858ad6724cf8c27299569bd72193c77bb339883214a4477c0762\
+        f9cf31a2d698562f57dff5ede03d6928feba694975445e7dabe3d67e67b710f26\
+        11f4f14471917bd447d199c32eb93dbcaf1fdbefe05132911991"
+    );
+}
+
+#[test]
+fn blake2b() {
+    let mut out = [0u8; 63];
+
+    udigest::hash_vof::<blake2::Blake2bVar, _>(&ALICE, &mut out).unwrap();
+    assert_eq!(
+        hex::encode(&out),
+        "91d1ce144fd46ed5400895c8db5f2b39c95870020c6627af034a9fa09c2f2cc3\
+        f4c8c7d4e8d38ff16e4f54360b4387c0439cf30c51c21c78f904cda9205023"
+    );
+
+    udigest::hash_vof::<blake2::Blake2bVar, _>(&BOB, &mut out).unwrap();
+    assert_eq!(
+        hex::encode(&out),
+        "2f916c687c82c0f37d31df061c0453e98d0655e1877d4a55ec1507514822a2c4\
+        b7cac3ca66a5e3deb678f915210e93f2fc14591b987f121083623ab024ece4"
+    );
+}

--- a/udigest/tests/inline_struct.rs
+++ b/udigest/tests/inline_struct.rs
@@ -6,12 +6,12 @@ fn no_tag() {
         age: u32,
     }
 
-    let hash_expected = udigest::hash::<sha2::Sha256, _>(&Person {
+    let hash_expected = udigest::hash::<sha2::Sha256>(&Person {
         name: "Alice",
         age: 24,
     });
 
-    let hash_actual = udigest::hash::<sha2::Sha256, _>(&udigest::inline_struct!({
+    let hash_actual = udigest::hash::<sha2::Sha256>(&udigest::inline_struct!({
         name: "Alice",
         age: 24_u32,
     }));
@@ -28,12 +28,12 @@ fn with_tag() {
         age: u32,
     }
 
-    let hash_expected = udigest::hash::<sha2::Sha256, _>(&Person {
+    let hash_expected = udigest::hash::<sha2::Sha256>(&Person {
         name: "Alice",
         age: 24,
     });
 
-    let hash_actual = udigest::hash::<sha2::Sha256, _>(&udigest::inline_struct!("some_tag" {
+    let hash_actual = udigest::hash::<sha2::Sha256>(&udigest::inline_struct!("some_tag" {
         name: "Alice",
         age: 24_u32,
     }));
@@ -55,7 +55,7 @@ fn embedded_structs() {
         receive_newsletter: bool,
     }
 
-    let hash_expected = udigest::hash::<sha2::Sha256, _>(&Person {
+    let hash_expected = udigest::hash::<sha2::Sha256>(&Person {
         name: "Alice",
         age: 24,
         preferences: Preferences {
@@ -64,7 +64,7 @@ fn embedded_structs() {
         },
     });
 
-    let hash_actual = udigest::hash::<sha2::Sha256, _>(&udigest::inline_struct!({
+    let hash_actual = udigest::hash::<sha2::Sha256>(&udigest::inline_struct!({
         name: "Alice",
         age: 24_u32,
         preferences: udigest::inline_struct!({

--- a/udigest/tests/inline_struct.rs
+++ b/udigest/tests/inline_struct.rs
@@ -1,0 +1,77 @@
+#[test]
+fn no_tag() {
+    #[derive(udigest::Digestable)]
+    struct Person {
+        name: &'static str,
+        age: u32,
+    }
+
+    let hash_expected = udigest::hash::<sha2::Sha256, _>(&Person {
+        name: "Alice",
+        age: 24,
+    });
+
+    let hash_actual = udigest::hash::<sha2::Sha256, _>(&udigest::inline_struct!({
+        name: "Alice",
+        age: 24_u32,
+    }));
+
+    assert_eq!(hex::encode(hash_expected), hex::encode(hash_actual));
+}
+
+#[test]
+fn with_tag() {
+    #[derive(udigest::Digestable)]
+    #[udigest(tag = "some_tag")]
+    struct Person {
+        name: &'static str,
+        age: u32,
+    }
+
+    let hash_expected = udigest::hash::<sha2::Sha256, _>(&Person {
+        name: "Alice",
+        age: 24,
+    });
+
+    let hash_actual = udigest::hash::<sha2::Sha256, _>(&udigest::inline_struct!("some_tag" {
+        name: "Alice",
+        age: 24_u32,
+    }));
+
+    assert_eq!(hex::encode(hash_expected), hex::encode(hash_actual));
+}
+
+#[test]
+fn embedded_structs() {
+    #[derive(udigest::Digestable)]
+    struct Person {
+        name: &'static str,
+        age: u32,
+        preferences: Preferences,
+    }
+    #[derive(udigest::Digestable)]
+    struct Preferences {
+        display_email: bool,
+        receive_newsletter: bool,
+    }
+
+    let hash_expected = udigest::hash::<sha2::Sha256, _>(&Person {
+        name: "Alice",
+        age: 24,
+        preferences: Preferences {
+            display_email: false,
+            receive_newsletter: false,
+        },
+    });
+
+    let hash_actual = udigest::hash::<sha2::Sha256, _>(&udigest::inline_struct!({
+        name: "Alice",
+        age: 24_u32,
+        preferences: udigest::inline_struct!({
+            display_email: false,
+            receive_newsletter: false,
+        })
+    }));
+
+    assert_eq!(hex::encode(hash_expected), hex::encode(hash_actual));
+}


### PR DESCRIPTION
- [x] Remove `udigest::Tag`
- [x] Add support of all hash functions (such as extendable-output hash function, etc.)
- [x] Add `udigest::inline_struct!`
- [x] fix: handle cases when `EncodeValue` is dropped without being used