### PR TITLE
Improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "udigest"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 dependencies = [
  "blake2",
  "digest",

--- a/README.md
+++ b/README.md
@@ -11,14 +11,13 @@ data can be anything that implements `Digestable` trait:
 * Integers:
   `i8`, `i16`, `i32`, `i64`, `i128`,
   `u8`, `u16`, `u32`, `u64`, `u128`,
-  `char`
+  `char`, `isize`, `usize`
 * Containers: `Box`, `Arc`, `Rc`, `Cow`, `Option`, `Result`
 * Collections: arrays, slices, `Vec`, `LinkedList`, `VecDeque`, `BTreeSet`, `BTreeMap`
 
 The trait is intentionally not implemented for certain types:
 
 * `HashMap`, `HashSet` as they can not be traversed in deterministic order
-* `usize`, `isize` as their byte size varies on different platforms
 
 The `Digestable` trait can be implemented for the struct using a macro:
 ```rust

--- a/udigest/CHANGELOG.md
+++ b/udigest/CHANGELOG.md
@@ -1,13 +1,16 @@
 ## v0.2.0
 * Breaking change: remove `udigest::Tag` [#4]
 * Breaking change: rename `udigest::udigest` function to `udigest::hash` [#4]
+* Breaking change: change format of integers encoding [#5]
 * Add support of all hash functions compatible with `digest` crate:
   hash functions with fixed output, with extendable output, and with
   variable output [#4]
 * Add `udigest::inline_struct!` macro [#4]
-* fix: handle cases when `EncodeValue` is dropped without being used
+* Add support for digesting `usize`/`isize` [#5]
+* fix: handle cases when `EncodeValue` is dropped without being used [#4]
 
 [#4]: https://github.com/dfns/udigest/pull/4
+[#5]: https://github.com/dfns/udigest/pull/5
 
 ## v0.1.0
 

--- a/udigest/Cargo.toml
+++ b/udigest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udigest"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Unambiguously digest structured data"

--- a/udigest/src/encoding.rs
+++ b/udigest/src/encoding.rs
@@ -66,8 +66,14 @@
 //!
 //! ### Primitive types
 //! Primitive values can be encoded as bytestrings as long as they can be unambiguously converted to bytes.
-//! For instance, any integer can be converted into bytes using [to_be_bytes](u32::to_be_bytes). Strings can
-//! be [converted to bytes](str::as_bytes) as well, and so on.
+//! For instance, strings are trivially converted to bytes via [`str::as_bytes`].
+//!
+//! Unsigned integers are encoded in big-endian representation truncated from leading zeroes. It allows
+//! us to unambiguously encode `usize` on different machines even if they have different size of machine
+//! word.
+//!
+//! Signed integers are encoded as concatenation of their sign and byte representation of their absolute
+//! value.
 //!
 //! ### Domain separation
 //! When value is encoded into bytes, it loses its type. For instance, "abcd" bytestring may correspond to

--- a/udigest/src/inline_struct.rs
+++ b/udigest/src/inline_struct.rs
@@ -192,8 +192,6 @@ pub trait FieldsList: sealed::Sealed {
 /// Normally, you don't need to use it directly. Use [`inline_struct!`] macro instead.
 pub fn builder() -> InlineStruct<'static, impl FieldsList> {
     /// Empty list of fields
-    ///
-    /// Normally, you don't need to use it directly. Use [`inline_struct!`] macro instead.
     pub struct Nil;
     impl sealed::Sealed for Nil {}
     impl FieldsList for Nil {

--- a/udigest/src/inline_struct.rs
+++ b/udigest/src/inline_struct.rs
@@ -40,14 +40,14 @@ impl<'a, F: FieldsList + 'a> InlineStruct<'a, F> {
     /// Adds field to the struct
     ///
     /// Normally, you don't need to use it directly. Use [`inline_struct!`] macro instead.
-    pub fn add_field<V: 'a>(
+    pub fn add_field<V>(
         self,
         field_name: &'a str,
         field_value: V,
     ) -> InlineStruct<'a, impl FieldsList + 'a>
     where
         F: 'a,
-        V: crate::Digestable,
+        V: crate::Digestable + 'a,
     {
         InlineStruct {
             fields_list: cons(field_name, field_value, self.fields_list),

--- a/udigest/src/lib.rs
+++ b/udigest/src/lib.rs
@@ -11,14 +11,13 @@
 //! * Integers:
 //!   `i8`, `i16`, `i32`, `i64`, `i128`,
 //!   `u8`, `u16`, `u32`, `u64`, `u128`,
-//!   `char`
+//!   `char`, `isize`, `usize`
 //! * Containers: `Box`, `Arc`, `Rc`, `Cow`, `Option`, `Result`
 //! * Collections: arrays, slices, `Vec`, `LinkedList`, `VecDeque`, `BTreeSet`, `BTreeMap`
 //!
 //! The trait is intentionally not implemented for certain types:
 //!
 //! * `HashMap`, `HashSet` as they can not be traversed in deterministic order
-//! * `usize`, `isize` as their byte size varies on different platforms
 //!
 //! The `Digestable` trait can be implemented for the struct using [a macro](derive@Digestable):
 //! ```rust
@@ -312,17 +311,61 @@ impl<T: AsRef<[u8]> + ?Sized> Digestable for Bytes<T> {
     }
 }
 
-macro_rules! digestable_integers {
+macro_rules! digestable_signed_integers {
     ($($type:ty),*) => {$(
         impl Digestable for $type {
             fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
-                encoder.encode_leaf().chain(self.to_be_bytes());
+                encode_signed_integer(
+                    self.is_positive(),
+                    &self.unsigned_abs().to_be_bytes(),
+                    encoder,
+                )
             }
         }
     )*};
 }
 
-digestable_integers!(i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
+/// Encodes an integer without leading zeroes
+fn encode_signed_integer<B: Buffer>(
+    is_positive: bool,
+    abs_be_bytes: &[u8],
+    encoder: encoding::EncodeValue<B>,
+) {
+    let leading_zeroes = abs_be_bytes.iter().take_while(|b| **b == 0).count();
+    let truncated_be_bytes = if leading_zeroes < abs_be_bytes.len() {
+        &abs_be_bytes[leading_zeroes..]
+    } else {
+        &[0]
+    };
+    encoder
+        .encode_leaf()
+        .chain([u8::from(is_positive)])
+        .chain(truncated_be_bytes)
+        .finish()
+}
+
+macro_rules! digestable_unsigned_integers {
+    ($($type:ty),*) => {$(
+        impl Digestable for $type {
+            fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+                encode_unsigned_integer(&self.to_be_bytes(), encoder)
+            }
+        }
+    )*};
+}
+
+/// Encodes an integer without leading zeroes
+fn encode_unsigned_integer<B: Buffer>(be_bytes: &[u8], encoder: encoding::EncodeValue<B>) {
+    let leading_zeroes = be_bytes.iter().take_while(|b| **b == 0).count();
+    encoder.encode_leaf_value(if leading_zeroes < be_bytes.len() {
+        &be_bytes[leading_zeroes..]
+    } else {
+        &[0]
+    })
+}
+
+digestable_signed_integers!(i8, i16, i32, i64, i128, isize);
+digestable_unsigned_integers!(u8, u16, u32, u64, u128, usize);
 
 impl Digestable for bool {
     fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {

--- a/udigest/tests/deterministic_hash.rs
+++ b/udigest/tests/deterministic_hash.rs
@@ -22,13 +22,13 @@ fn sha2_256() {
     let alice_hash = udigest::hash::<sha2::Sha256>(&ALICE);
     assert_eq!(
         hex::encode(alice_hash.as_slice()),
-        "99e258d6a6ccc430a50dcbf4e9c8cfb59ad0b94b96b83f0182a9a68eb1c5438f",
+        "49c43095eaffb3e3232dd23940686d3c6fb80e5ff82b5a09d336ad32369ca9df",
     );
 
     let bob_hash = udigest::hash::<sha2::Sha256>(&BOB);
     assert_eq!(
         hex::encode(bob_hash.as_slice()),
-        "28474b5dec79b222b74badc2d78f9f81c0fbfd1ee04a134947cd07f44237ade3",
+        "3537c188336cb93f58df79149fb035fd132f23fac58a6e94d014178aeaa1c88e",
     );
 }
 
@@ -41,20 +41,20 @@ fn shake256() {
     alice_hash_reader.read(&mut hash);
     assert_eq!(
         hex::encode(&hash),
-        "54809cf7b06438f9508785fb5e46bdfd7714b39b026e86fa7cc8a8442ae10bd5\
-        49baeced19ff0642b042ae4e92636536baec5748dad99e71fc53a4361734973ae\
-        2c4f1547305a76addd5b6076509ddbf91bd5beb71ba09598e265704d1e9a1c0c3\
-        5fae7f8e4958ceb38962fc8e6fc56e32bef4e88f64bc8a88f88a"
+        "ee629bcc426422887fe6f9a9a3384128bd5efc3c623a4599c8526c24a97972be\
+        2a325ef03c95ac649b77f0193c901c942762e93fd939372ef484681220c6fc0b\
+        0dc12be8c6b9ee914dac34697d0deeb3a3e510f24a1b0bfc24d144b639a66c6a\
+        4c5a772b178eed159f87b581bb49aafdcdcca525fd57749aab6c32"
     );
 
     let mut bob_hash_reader = udigest::hash_xof::<sha3::Shake256>(&BOB);
     bob_hash_reader.read(&mut hash);
     assert_eq!(
         hex::encode(&hash),
-        "f68ca9eeb7e09657fc54a5cbbd50acdd6d9fccd29ec1a3eb460b673ea59d64a9\
-        b2ec8be97c7d7858ad6724cf8c27299569bd72193c77bb339883214a4477c0762\
-        f9cf31a2d698562f57dff5ede03d6928feba694975445e7dabe3d67e67b710f26\
-        11f4f14471917bd447d199c32eb93dbcaf1fdbefe05132911991"
+        "56cd71e796fc94176923b73bfe3f659ea7a9a666a2faae6020d1c4f41a51035a\
+        e7965583087f1badf452a40036499d54075350d8e64e5b68b0f3f52c286c15e3\
+        cb010249754a0c7f263d14c7a284da134ca133df84c62d80adfdb0ec0d5c3f0a\
+        50e479dd025b27fb875c34ba72d9abc7a5990ce8c7f3c282dd6a0c"
     );
 }
 
@@ -65,14 +65,14 @@ fn blake2b() {
     udigest::hash_vof::<blake2::Blake2bVar>(&ALICE, &mut out).unwrap();
     assert_eq!(
         hex::encode(&out),
-        "91d1ce144fd46ed5400895c8db5f2b39c95870020c6627af034a9fa09c2f2cc3\
-        f4c8c7d4e8d38ff16e4f54360b4387c0439cf30c51c21c78f904cda9205023"
+        "57b2a8a078ca3b04dc72b308696bc4715c62593b461608bff01388ef3bd49fed\
+        244bd2e9407965ec2bfe13781ae3cd28ea0cb08fb4b46824ea7909c488fec8"
     );
 
     udigest::hash_vof::<blake2::Blake2bVar>(&BOB, &mut out).unwrap();
     assert_eq!(
         hex::encode(&out),
-        "2f916c687c82c0f37d31df061c0453e98d0655e1877d4a55ec1507514822a2c4\
-        b7cac3ca66a5e3deb678f915210e93f2fc14591b987f121083623ab024ece4"
+        "83aa6240d105ec1b496e6963dbab3e48fd09860b734c963b59ee764781d922f1\
+        207405232c1d84965b32f6a73b182b224d1533859f586c332377fe4a39489e"
     );
 }

--- a/udigest/tests/encoding.rs
+++ b/udigest/tests/encoding.rs
@@ -201,7 +201,7 @@ fn encode_integers() {
         assert_eq!(lhs, rhs, "{lhs:?} != {rhs:?}");
     }
 
-    expect(0_u16, &[0]);
+    expect(0_u16, &[]);
     expect(1_u16, &[1]);
     expect(255_u16, &[255]);
     expect(256_u16, &[1, 0]);
@@ -210,7 +210,7 @@ fn encode_integers() {
     expect_eq(1000_u16, 1000_usize);
     expect_eq(1_000_000_usize, 1_000_000_u64);
 
-    expect(0_i16, &[0, 0]);
+    expect(0_i16, &[]);
     expect(1_i16, &[1, 1]);
     expect(255_i16, &[1, 255]);
     expect(256_i16, &[1, 1, 0]);

--- a/udigest/tests/inline_struct.rs
+++ b/udigest/tests/inline_struct.rs
@@ -75,3 +75,28 @@ fn embedded_structs() {
 
     assert_eq!(hex::encode(hash_expected), hex::encode(hash_actual));
 }
+
+#[test]
+fn shorter_syntax() {
+    let name = "Alice";
+    let age = 24_u32;
+    let alice1 = udigest::inline_struct!({
+        name,
+        age,
+    });
+
+    let name = name.to_owned();
+    let alice2 = udigest::inline_struct!({
+        &name,
+        age,
+    });
+
+    assert_eq!(
+        udigest::hash::<sha2::Sha256>(&alice1),
+        udigest::hash::<sha2::Sha256>(&alice2),
+    );
+    drop(alice2);
+
+    // `name` is not consumed
+    drop(name);
+}


### PR DESCRIPTION
* Change encoding of integers so `usize`/`isize` are supported
* Improve `inline_struct!`
  * Add shorter syntax for `inline_struct!({ field: field })`, now it's possible to write `inline_struct!({ field })`
  * Do not reference the fields unless explicitly asked to. Useful when we want to return inlined struct from the function.