### PR TITLE
Fix `udigest-derive` causing clippy warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
         cache-on-failure: "true"
     - name: Check docs
       run: RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps
-  check-clippy:
+  clippy:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -67,6 +67,15 @@ jobs:
         cache-on-failure: "true"
     - name: Run clippy
       run: cargo clippy --all-features -- -D clippy::all
+  clippy-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v2
+      with:
+        cache-on-failure: "true"
+    - name: Run clippy
+      run: cargo clippy --all-features --tests -- -D clippy::all
   check-changelog:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "udigest"
-version = "0.2.0-rc2"
+version = "0.2.0-rc3"
 dependencies = [
  "blake2",
  "digest",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "udigest-derive"
-version = "0.1.0"
+version = "0.2.0-rc3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,23 +158,12 @@ dependencies = [
  "hex",
  "sha2",
  "sha3",
- "udigest-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "udigest-derive",
 ]
 
 [[package]]
 name = "udigest-derive"
 version = "0.1.0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "udigest-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b29f121da05aa0857e7b96cf2f8782bd4140911506518486d4a125b97d7d609"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/udigest-derive/CHANGELOG.md
+++ b/udigest-derive/CHANGELOG.md
@@ -1,0 +1,8 @@
+## v0.2.0
+* Fix proc macro causing clippy warnings in certain cases [#6]
+
+[#6]: https://github.com/dfns/udigest/pull/6
+
+## v0.1.0
+
+The first release!

--- a/udigest-derive/Cargo.toml
+++ b/udigest-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udigest-derive"
-version = "0.1.0"
+version = "0.2.0-rc3"
 edition = "2021"
 description = "Proc macro for `udigest` crate"
 license = "MIT OR Apache-2.0"

--- a/udigest-derive/src/lib.rs
+++ b/udigest-derive/src/lib.rs
@@ -399,16 +399,17 @@ fn encode_field(
                 let field_encoder = #encoder_var.add_field(#field_name);
                 let field_bytes = #func(#field_ref);
                 let field_bytes = AsRef::<[u8]>::as_ref(&field_bytes);
-                field_encoder.encode_leaf().chain(field_bytes);
+                field_encoder.encode_leaf_value(field_bytes);
             }},
             None => quote_spanned!(field_span => {
                 let field_encoder = #encoder_var.add_field(#field_name);
                 let field_bytes: &[u8] = AsRef::<[u8]>::as_ref(#field_ref);
-                field_encoder.encode_leaf().chain(field_bytes);
+                field_encoder.encode_leaf_value(field_bytes);
             }),
         },
         (None, Some(attrs::With { value: func, .. })) => quote_spanned! {field_span => {
             let field_encoder = #encoder_var.add_field(#field_name);
+            #[allow(clippy::needless_borrow)]
             #func(#field_ref, field_encoder);
         }},
         (None, None) => quote_spanned! {field_span => {

--- a/udigest/CHANGELOG.md
+++ b/udigest/CHANGELOG.md
@@ -8,9 +8,11 @@
 * Add `udigest::inline_struct!` macro [#4]
 * Add support for digesting `usize`/`isize` [#5]
 * fix: handle cases when `EncodeValue` is dropped without being used [#4]
+* fix: proc macro used to cause clippy warnings in certain cases [#6]
 
 [#4]: https://github.com/dfns/udigest/pull/4
 [#5]: https://github.com/dfns/udigest/pull/5
+[#6]: https://github.com/dfns/udigest/pull/6
 
 ## v0.1.0
 

--- a/udigest/Cargo.toml
+++ b/udigest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udigest"
-version = "0.2.0-rc2"
+version = "0.2.0-rc3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Unambiguously digest structured data"
@@ -18,7 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 digest = { version = "0.10", default-features = false, optional = true }
 
-udigest-derive = { version = "0.1", optional = true }
+udigest-derive = { version = "0.2.0-rc3", path = "../udigest-derive", optional = true }
 
 [dev-dependencies]
 hex = "0.4"

--- a/udigest/tests/derive.rs
+++ b/udigest/tests/derive.rs
@@ -92,3 +92,13 @@ mod encoding {
         list.finish()
     }
 }
+
+#[derive(udigest::Digestable)]
+pub struct StructWithRefs<'a> {
+    field1: &'a str,
+    #[udigest(as_bytes)]
+    field2: &'a [u8],
+    field3: &'a String,
+    #[udigest(with = encoding::encode_bar)]
+    field4: &'a Bar,
+}

--- a/udigest/tests/deterministic_hash.rs
+++ b/udigest/tests/deterministic_hash.rs
@@ -40,7 +40,7 @@ fn shake256() {
     let mut alice_hash_reader = udigest::hash_xof::<sha3::Shake256>(&ALICE);
     alice_hash_reader.read(&mut hash);
     assert_eq!(
-        hex::encode(&hash),
+        hex::encode(hash),
         "ee629bcc426422887fe6f9a9a3384128bd5efc3c623a4599c8526c24a97972be\
         2a325ef03c95ac649b77f0193c901c942762e93fd939372ef484681220c6fc0b\
         0dc12be8c6b9ee914dac34697d0deeb3a3e510f24a1b0bfc24d144b639a66c6a\
@@ -50,7 +50,7 @@ fn shake256() {
     let mut bob_hash_reader = udigest::hash_xof::<sha3::Shake256>(&BOB);
     bob_hash_reader.read(&mut hash);
     assert_eq!(
-        hex::encode(&hash),
+        hex::encode(hash),
         "56cd71e796fc94176923b73bfe3f659ea7a9a666a2faae6020d1c4f41a51035a\
         e7965583087f1badf452a40036499d54075350d8e64e5b68b0f3f52c286c15e3\
         cb010249754a0c7f263d14c7a284da134ca133df84c62d80adfdb0ec0d5c3f0a\
@@ -64,14 +64,14 @@ fn blake2b() {
 
     udigest::hash_vof::<blake2::Blake2bVar>(&ALICE, &mut out).unwrap();
     assert_eq!(
-        hex::encode(&out),
+        hex::encode(out),
         "57b2a8a078ca3b04dc72b308696bc4715c62593b461608bff01388ef3bd49fed\
         244bd2e9407965ec2bfe13781ae3cd28ea0cb08fb4b46824ea7909c488fec8"
     );
 
     udigest::hash_vof::<blake2::Blake2bVar>(&BOB, &mut out).unwrap();
     assert_eq!(
-        hex::encode(&out),
+        hex::encode(out),
         "83aa6240d105ec1b496e6963dbab3e48fd09860b734c963b59ee764781d922f1\
         207405232c1d84965b32f6a73b182b224d1533859f586c332377fe4a39489e"
     );


### PR DESCRIPTION
proc macro was causing a clippy warning in this structure:

```rust
#[derive(Debug, Clone, Copy, udigest::Digestable)]
#[udigest(bound = "")]
pub struct Data<'a, C: Curve> {
    #[udigest(with = crate::common::digest_integer)]
    pub c: &'a Ciphertext,
    // ...
}
```

The warning:

```text
warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/group_element_vs_paillier_encryption_in_range.rs:135:9
    |
135 |     pub c: &'a Ciphertext,
    |         ^ help: change this to: `c`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
    = note: `#[warn(clippy::needless_borrow)]` on by default
```