### PR TITLE
Impl Clone/Copy for InlineStruct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "udigest"
-version = "0.2.0-rc3"
+version = "0.2.0-rc4"
 dependencies = [
  "blake2",
  "digest",

--- a/udigest/Cargo.toml
+++ b/udigest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udigest"
-version = "0.2.0-rc3"
+version = "0.2.0-rc4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Unambiguously digest structured data"

--- a/udigest/src/inline_struct.rs
+++ b/udigest/src/inline_struct.rs
@@ -47,6 +47,12 @@ impl InlineStruct<'static, Nil> {
     }
 }
 
+impl Default for InlineStruct<'static, Nil> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'t, F: FieldsList> InlineStruct<'t, F> {
     /// Adds field to the struct
     ///
@@ -68,7 +74,7 @@ impl<'t, F: FieldsList> InlineStruct<'t, F> {
     /// Sets domain-separation tag
     ///
     /// Normally, you don't need to use it directly. Use [`inline_struct!`] macro instead.
-    pub fn set_tag<'t2, T: ?Sized + AsRef<[u8]>>(self, tag: &'t2 T) -> InlineStruct<'t2, F> {
+    pub fn set_tag<T: ?Sized + AsRef<[u8]>>(self, tag: &T) -> InlineStruct<F> {
         InlineStruct {
             fields_list: self.fields_list,
             tag: Some(tag.as_ref()),
@@ -234,7 +240,7 @@ impl<'a, V: crate::Digestable, T: FieldsList> FieldsList for Cons<'a, V, T> {
     }
 }
 
-fn cons<'a, V, T>(field_name: &'a str, field_value: V, tail: T) -> Cons<'a, V, T>
+fn cons<V, T>(field_name: &str, field_value: V, tail: T) -> Cons<V, T>
 where
     V: crate::Digestable,
     T: FieldsList,

--- a/udigest/tests/inline_struct.rs
+++ b/udigest/tests/inline_struct.rs
@@ -95,8 +95,30 @@ fn shorter_syntax() {
         udigest::hash::<sha2::Sha256>(&alice1),
         udigest::hash::<sha2::Sha256>(&alice2),
     );
-    drop(alice2);
+    let _ = alice2;
 
     // `name` is not consumed
     drop(name);
+}
+
+#[test]
+fn impls_clone_copy() {
+    fn impls_clone<T: Clone>(_: &T) {}
+    fn impls_copy<T: Copy>(_: &T) {}
+
+    let name = "Alice".to_owned();
+    let age = 24_u32;
+
+    let alice = udigest::inline_struct!({
+        name,
+        age,
+    });
+    impls_clone(&alice);
+
+    let name = "Alice";
+    let alice = udigest::inline_struct!({
+        name,
+        age,
+    });
+    impls_copy(&alice);
 }


### PR DESCRIPTION
Initially I made that `InlineStruct` hides the type of the inner list for API simplicity, but that turned out to be a limitation when we want `InlineStruct` to implement Clone/Copy when all its fields are Clone/Copy. PR fixes that flaw so now `InlineStruct` implements Clone/Copy when it's possible