### PR TITLE
Add contribution guidelines, update the license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing Guide
+
+Thanks for taking interest to contributing to our project!
+
+## Pull Requests
+Prior to making a PR, we ask you to communicate it with us, preferably by opening an issue.
+This would help to keep your work aligned with the maintainers view and get insights from
+them.
+
+All commits are required to be signed via verified GPG key. You can read about commit signing
+in [this series of articles](https://docs.github.com/en/authentication/managing-commit-signature-verification)
+(we recommend using a hardware GPG token).
+
+All commits are required to be signed off by including `Signed-off-by: YOUR NAME <your_email@example.com` line.
+By doing this, you certify that the commit is compliant with [Developer Certificate of Origin (DCO)](https://developercertificate.org/),
+meaning that you wrote the code or otherwise have the right to submit the code you are
+contributing to the project.
+
+```text
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+## Issues
+Feel free to open an issue if you found a bug, have a suggestion, or wish to
+communicate with us for other reasons.
+
+However, if you want to report something that you believe might be a security
+vulnerability or a security flaw in this or any upstream project, please report
+it following the procedure described in [SECURITY.md].

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,10 +53,12 @@ By making a contribution to this project, I certify that:
     this project or the open source license(s) involved.
 ```
 
+Commits can be automatically signed off automatically by using `-s` flag (i.e. `git commit -s`).
+
 ## Issues
 Feel free to open an issue if you found a bug, have a suggestion, or wish to
 communicate with us for other reasons.
 
 However, if you want to report something that you believe might be a security
 vulnerability or a security flaw in this or any upstream project, please report
-it following the procedure described in [SECURITY.md].
+it following the procedure described in [SECURITY.md](./SECURITY.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ All commits are required to be signed via verified GPG key. You can read about c
 in [this series of articles](https://docs.github.com/en/authentication/managing-commit-signature-verification)
 (we recommend using a hardware GPG token).
 
-All commits are required to be signed off by including `Signed-off-by: YOUR NAME <your_email@example.com` line.
+All commits are required to be signed off by including `Signed-off-by: YOUR NAME <your_email@example.com>` line.
 By doing this, you certify that the commit is compliant with [Developer Certificate of Origin (DCO)](https://developercertificate.org/),
 meaning that you wrote the code or otherwise have the right to submit the code you are
 contributing to the project.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest version of the library is supported.
+
+## Reporting a Vulnerability
+
+We ask to report any security vulnerabilities or flaws through:
+
+1. Github, in the "Security" tab, using the "Report a vulnerability" button.
+2. Email, security@dfns.co
+
+After receiving the report, it will take us up to 2 working days to respond. 
+We will evaluate the reported vulnerability, determine whether it needs to 
+be addressed, and (if so) and provide an estimated timeline for addressing it.
+
+After vulnerability was fixed and the new version of the library was
+properly tested, we publish the fix, and publicly disclose the vulnerability
+(credits for finding the issue go to the reporter).


### PR DESCRIPTION
* Add `CONTRIBUTING.md` which mentions that we have DCO and GPG signing requirements
* Add `SECURITY.md` with guidelines for reporting security-related findings