### PR TITLE
Add DigestAs functionality

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_NET_GIT_FETCH_WITH_CLI: true
+  RUSTFLAGS: -D warnings
 
 jobs:
   check-and-test:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,9 +21,9 @@ jobs:
       with:
         cache-on-failure: "true"
     - name: Check
-      run: cargo check -p udigest --features "${{ matrix.features }}"
+      run: cargo check -p udigest --no-default-features --features "${{ matrix.features }}"
     - name: Run tests
-      run: cargo test -p udigest --lib --tests --features "${{ matrix.features }}"
+      run: cargo test -p udigest --lib --tests --no-default-features --features "${{ matrix.features }}"
   test-all-features:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "udigest"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "blake2",
  "digest",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "udigest-derive"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "udigest"
-version = "0.2.0-rc4"
+version = "0.2.0"
 dependencies = [
  "blake2",
  "digest",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "udigest-derive"
-version = "0.2.0-rc3"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/udigest-derive/CHANGELOG.md
+++ b/udigest-derive/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.3.0
+* Add `#[udigest(as = ...)]` attribute support [#12]
+
+[#12]: https://github.com/dfns/udigest/pull/12
+
 ## v0.2.0
 * Fix proc macro causing clippy warnings in certain cases [#6]
 

--- a/udigest-derive/Cargo.toml
+++ b/udigest-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udigest-derive"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Proc macro for `udigest` crate"
 license = "MIT OR Apache-2.0"

--- a/udigest-derive/src/attrs.rs
+++ b/udigest-derive/src/attrs.rs
@@ -18,6 +18,7 @@ pub enum Attr {
     Skip(Skip),
     Rename(Rename),
     With(With),
+    As(As),
 }
 
 impl Attr {
@@ -30,6 +31,7 @@ impl Attr {
             Attr::Skip(attr) => attr.skip.span,
             Attr::Rename(attr) => attr.rename.span,
             Attr::With(attr) => attr.with.span,
+            Attr::As(attr) => attr.as_.span,
         }
     }
 }
@@ -51,6 +53,8 @@ impl syn::parse::Parse for Attr {
             Rename::parse(input).map(Attr::Rename)
         } else if lookahead.peek(kw::with) {
             With::parse(input).map(Attr::With)
+        } else if lookahead.peek(syn::Token![as]) {
+            As::parse(input).map(Attr::As)
         } else {
             Err(lookahead.error())
         }
@@ -172,5 +176,20 @@ impl syn::parse::Parse for With {
         let _eq = input.parse()?;
         let value = input.parse()?;
         Ok(Self { with, _eq, value })
+    }
+}
+
+pub struct As {
+    pub as_: syn::Token![as],
+    pub _eq: syn::Token![=],
+    pub value: syn::Type,
+}
+
+impl syn::parse::Parse for As {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let as_ = input.parse()?;
+        let _eq = input.parse()?;
+        let value = input.parse()?;
+        Ok(Self { as_, _eq, value })
     }
 }

--- a/udigest-derive/src/attrs.rs
+++ b/udigest-derive/src/attrs.rs
@@ -59,7 +59,7 @@ impl syn::parse::Parse for Attr {
 
 pub struct Root {
     pub root: kw::root,
-    pub eq: syn::Token![=],
+    pub _eq: syn::Token![=],
     pub path: RootPath,
 }
 
@@ -68,50 +68,50 @@ pub type RootPath = syn::punctuated::Punctuated<syn::Ident, syn::Token![::]>;
 impl syn::parse::Parse for Root {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let root = input.parse::<kw::root>()?;
-        let eq = input.parse::<syn::Token![=]>()?;
+        let _eq = input.parse::<syn::Token![=]>()?;
         let path = RootPath::parse_separated_nonempty_with(input, syn::Ident::parse_any)?;
 
-        Ok(Self { root, eq, path })
+        Ok(Self { root, _eq, path })
     }
 }
 
 pub struct Tag {
     pub tag: kw::tag,
-    pub eq: syn::Token![=],
+    pub _eq: syn::Token![=],
     pub value: syn::Expr,
 }
 
 impl syn::parse::Parse for Tag {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let tag = input.parse()?;
-        let eq = input.parse()?;
+        let _eq = input.parse()?;
         let value = input.parse()?;
 
-        Ok(Self { tag, eq, value })
+        Ok(Self { tag, _eq, value })
     }
 }
 
 pub struct AsBytes {
     pub as_bytes: kw::as_bytes,
-    pub eq: Option<syn::Token![=]>,
+    pub _eq: Option<syn::Token![=]>,
     pub value: Option<syn::Expr>,
 }
 
 impl syn::parse::Parse for AsBytes {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let as_bytes = input.parse()?;
-        let mut eq = None;
+        let mut _eq = None;
         let mut value = None;
 
         let lookahead = input.lookahead1();
         if lookahead.peek(syn::Token![=]) {
-            eq = Some(input.parse()?);
+            _eq = Some(input.parse()?);
             value = Some(input.parse()?);
         }
 
         Ok(Self {
             as_bytes,
-            eq,
+            _eq,
             value,
         })
     }
@@ -119,17 +119,17 @@ impl syn::parse::Parse for AsBytes {
 
 pub struct Bound {
     pub bound: kw::bound,
-    pub eq: syn::Token![=],
+    pub _eq: syn::Token![=],
     pub value: syn::LitStr,
 }
 
 impl syn::parse::Parse for Bound {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let bound = input.parse()?;
-        let eq = input.parse()?;
+        let _eq = input.parse()?;
         let value = input.parse()?;
 
-        Ok(Self { bound, eq, value })
+        Ok(Self { bound, _eq, value })
     }
 }
 
@@ -146,31 +146,31 @@ impl syn::parse::Parse for Skip {
 
 pub struct Rename {
     pub rename: kw::rename,
-    pub eq: syn::Token![=],
+    pub _eq: syn::Token![=],
     pub value: syn::Expr,
 }
 
 impl syn::parse::Parse for Rename {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let rename = input.parse()?;
-        let eq = input.parse()?;
+        let _eq = input.parse()?;
         let value = input.parse()?;
 
-        Ok(Self { rename, eq, value })
+        Ok(Self { rename, _eq, value })
     }
 }
 
 pub struct With {
     pub with: kw::with,
-    pub eq: syn::Token![=],
+    pub _eq: syn::Token![=],
     pub value: syn::Expr,
 }
 
 impl syn::parse::Parse for With {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let with = input.parse()?;
-        let eq = input.parse()?;
+        let _eq = input.parse()?;
         let value = input.parse()?;
-        Ok(Self { with, eq, value })
+        Ok(Self { with, _eq, value })
     }
 }

--- a/udigest/CHANGELOG.md
+++ b/udigest/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.3.0
+* Add `#[udigest(as = ...)]` attribute and `DeriveAs` trait [#12]
+
+[#12]: https://github.com/dfns/udigest/pull/12
+
 ## v0.2.0
 * Breaking change: remove `udigest::Tag` [#4]
 * Breaking change: rename `udigest::udigest` function to `udigest::hash` [#4]

--- a/udigest/Cargo.toml
+++ b/udigest/Cargo.toml
@@ -49,6 +49,11 @@ required-features = ["derive", "digest"]
 name = "inline_struct"
 required-features = ["derive", "inline-struct"]
 
+[[test]]
+name = "digest_as"
+required-features = ["derive", "inline-struct"]
+
 [[example]]
 name = "derivation"
 required-features = ["std", "derive", "digest"]
+

--- a/udigest/Cargo.toml
+++ b/udigest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udigest"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Unambiguously digest structured data"
@@ -18,7 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 digest = { version = "0.10", default-features = false, optional = true }
 
-udigest-derive = { version = "0.2", path = "../udigest-derive", optional = true }
+udigest-derive = { version = "0.3", path = "../udigest-derive", optional = true }
 
 [dev-dependencies]
 hex = "0.4"

--- a/udigest/src/as_.rs
+++ b/udigest/src/as_.rs
@@ -2,13 +2,13 @@
 //!
 //! It's supposed to be used in a pair with derive proc macro and `as` attribute.
 //! For instance, it can be used to digest a hash map "as a btree map":
-//!   ```rust
-//!   #[derive(udigest::Digestable)]
-//!   pub struct Attributes(
-//!       #[udigest(as = std::collections::BTreeMap<_, udigest::Bytes>)]
-//!       std::collections::HashMap<String, Vec<u8>>,
-//!   );
-//!   ```
+//! ```rust
+//! #[derive(udigest::Digestable)]
+//! pub struct Attributes(
+//!     #[udigest(as = std::collections::BTreeMap<_, udigest::Bytes>)]
+//!     std::collections::HashMap<String, Vec<u8>>,
+//! );
+//! ```
 //!
 //! See more examples in [macro@Digestable] macro docs.
 

--- a/udigest/src/as_.rs
+++ b/udigest/src/as_.rs
@@ -222,7 +222,7 @@ where
     ) {
         let ordered_map = value
             .iter()
-            .map(|x| As::<&T, &U>::new(x))
+            .map(As::<&T, &U>::new)
             .collect::<alloc::collections::BTreeSet<_>>();
 
         // ordered set has deterministic order, so we can reproducibly hash it

--- a/udigest/src/as_.rs
+++ b/udigest/src/as_.rs
@@ -1,4 +1,16 @@
 //! Provides utilities for custom digesting rules
+//!
+//! It's supposed to be used in a pair with derive proc macro and `as` attribute.
+//! For instance, it can be used to digest a hash map "as a btree map":
+//!   ```rust
+//!   #[derive(udigest::Digestable)]
+//!   pub struct Attributes(
+//!       #[udigest(as = std::collections::BTreeMap<_, udigest::Bytes>)]
+//!       std::collections::HashMap<String, Vec<u8>>,
+//!   );
+//!   ```
+//!
+//! See more examples in [macro@Digestable] macro docs.
 
 use crate::{encoding, Buffer, Digestable};
 

--- a/udigest/src/as_.rs
+++ b/udigest/src/as_.rs
@@ -152,7 +152,7 @@ where
         crate::unambiguously_encode_iter(encoder, value.iter().map(As::<&T, &U>::new))
     }
 }
-
+#[cfg(feature = "alloc")]
 impl<T, U> DigestAs<alloc::collections::LinkedList<T>> for alloc::collections::LinkedList<U>
 where
     U: DigestAs<T>,
@@ -164,6 +164,7 @@ where
         crate::unambiguously_encode_iter(encoder, value.iter().map(As::<&T, &U>::new))
     }
 }
+#[cfg(feature = "alloc")]
 impl<T, U> DigestAs<alloc::collections::VecDeque<T>> for alloc::collections::VecDeque<U>
 where
     U: DigestAs<T>,
@@ -175,6 +176,7 @@ where
         crate::unambiguously_encode_iter(encoder, value.iter().map(As::<&T, &U>::new))
     }
 }
+#[cfg(feature = "alloc")]
 impl<T, U> DigestAs<alloc::collections::BTreeSet<T>> for alloc::collections::BTreeSet<U>
 where
     U: DigestAs<T>,

--- a/udigest/src/as_.rs
+++ b/udigest/src/as_.rs
@@ -76,8 +76,7 @@ where
     }
 }
 
-/// Digests any bytestring that implements `impl AsRef<[u8]>`
-pub type Bytes = crate::Bytes<()>;
+pub use crate::Bytes;
 
 impl<T> DigestAs<T> for Bytes
 where

--- a/udigest/src/as_.rs
+++ b/udigest/src/as_.rs
@@ -209,6 +209,27 @@ where
     }
 }
 
+/// Digests `HashSet` by transforming it into `BTreeSet`
+#[cfg(feature = "std")]
+impl<T, U> DigestAs<std::collections::HashSet<T>> for alloc::collections::BTreeSet<U>
+where
+    U: DigestAs<T>,
+    T: core::cmp::Ord,
+{
+    fn digest_as<B: Buffer>(
+        value: &std::collections::HashSet<T>,
+        encoder: encoding::EncodeValue<B>,
+    ) {
+        let ordered_map = value
+            .iter()
+            .map(|x| As::<&T, &U>::new(x))
+            .collect::<alloc::collections::BTreeSet<_>>();
+
+        // ordered set has deterministic order, so we can reproducibly hash it
+        ordered_map.unambiguously_encode(encoder)
+    }
+}
+
 /// Digests `HashMap` by transforming it into `BTreeMap`
 #[cfg(feature = "std")]
 impl<K, KAs, V, VAs> DigestAs<std::collections::HashMap<K, V>>

--- a/udigest/src/as_.rs
+++ b/udigest/src/as_.rs
@@ -304,3 +304,42 @@ where
         U::digest_as(value.as_ref(), encoder)
     }
 }
+
+macro_rules! impl_for_tuples {
+    ($($t:ident, $as:ident),*) => {
+        impl<$($t, $as),*> DigestAs<($($t,)*)> for ($($as,)*)
+        where
+            $($as: DigestAs<$t>),*
+        {
+            fn digest_as<Buf: Buffer>(value: &($($t,)*), encoder: encoding::EncodeValue<Buf>) {
+                #[allow(non_snake_case)]
+                let ($($t,)*) = value;
+                (
+                    $(As::<&$t, &$as>::new($t),)*
+                ).unambiguously_encode(encoder)
+            }
+        }
+    };
+}
+
+#[rustfmt::skip]
+mod tuples {
+    use super::*;
+
+    impl_for_tuples!(T, U);
+    impl_for_tuples!(T0, As0, T1, As1);
+    impl_for_tuples!(T0, As0, T1, As1, T2, As2);
+    impl_for_tuples!(T0, As0, T1, As1, T2, As2, T3, As3);
+    impl_for_tuples!(T0, As0, T1, As1, T2, As2, T3, As3, T4, As4);
+    impl_for_tuples!(T0, As0, T1, As1, T2, As2, T3, As3, T4, As4, T5, As5);
+    impl_for_tuples!(T0, As0, T1, As1, T2, As2, T3, As3, T4, As4, T5, As5, T6, As6);
+    impl_for_tuples!(T0, As0, T1, As1, T2, As2, T3, As3, T4, As4, T5, As5, T6, As6, T7, As7);
+    impl_for_tuples!(T0, As0, T1, As1, T2, As2, T3, As3, T4, As4, T5, As5, T6, As6, T7, As7, T8, As8);
+    impl_for_tuples!(T0, As0, T1, As1, T2, As2, T3, As3, T4, As4, T5, As5, T6, As6, T7, As7, T8, As8, T9, As9);
+    impl_for_tuples!(T0, As0, T1, As1, T2, As2, T3, As3, T4, As4, T5, As5, T6, As6, T7, As7, T8, As8, T9, As9, T10, As10);
+    impl_for_tuples!(T0, As0, T1, As1, T2, As2, T3, As3, T4, As4, T5, As5, T6, As6, T7, As7, T8, As8, T9, As9, T10, As10, T11, As11);
+    impl_for_tuples!(T0, As0, T1, As1, T2, As2, T3, As3, T4, As4, T5, As5, T6, As6, T7, As7, T8, As8, T9, As9, T10, As10, T11, As11, T12, As12);
+    impl_for_tuples!(T0, As0, T1, As1, T2, As2, T3, As3, T4, As4, T5, As5, T6, As6, T7, As7, T8, As8, T9, As9, T10, As10, T11, As11, T12, As12, T13, As13);
+    impl_for_tuples!(T0, As0, T1, As1, T2, As2, T3, As3, T4, As4, T5, As5, T6, As6, T7, As7, T8, As8, T9, As9, T10, As10, T11, As11, T12, As12, T13, As13, T14, As14);
+    impl_for_tuples!(T0, As0, T1, As1, T2, As2, T3, As3, T4, As4, T5, As5, T6, As6, T7, As7, T8, As8, T9, As9, T10, As10, T11, As11, T12, As12, T13, As13, T14, As14, T15, As15);
+}

--- a/udigest/src/as_.rs
+++ b/udigest/src/as_.rs
@@ -1,0 +1,272 @@
+//! Provides utilities for custom digesting rules
+
+use crate::{encoding, Buffer, Digestable};
+
+/// Custom rule for digesting an instance of `T`
+pub trait DigestAs<T: ?Sized> {
+    /// Digests `value`
+    fn digest_as<B: Buffer>(value: &T, encoder: encoding::EncodeValue<B>);
+}
+
+impl<T, U> DigestAs<&T> for &U
+where
+    U: DigestAs<T>,
+{
+    fn digest_as<B: Buffer>(value: &&T, encoder: encoding::EncodeValue<B>) {
+        U::digest_as(*value, encoder)
+    }
+}
+
+/// Stores `T`, digests it using `DigestAs<T>` implementation of `U`
+pub struct As<T, U> {
+    value: T,
+    _rule: core::marker::PhantomData<U>,
+}
+
+impl<T, U> As<T, U> {
+    /// Constructor
+    pub const fn new(value: T) -> Self {
+        Self {
+            value,
+            _rule: core::marker::PhantomData,
+        }
+    }
+
+    /// Returns stored value
+    pub fn into_inner(self) -> T {
+        self.value
+    }
+}
+
+impl<T, U> Digestable for As<T, U>
+where
+    U: DigestAs<T>,
+{
+    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+        U::digest_as(&self.value, encoder)
+    }
+}
+
+impl<T: core::cmp::PartialEq, U> core::cmp::PartialEq for As<T, U> {
+    fn eq(&self, other: &Self) -> bool {
+        self.value.eq(&other.value)
+    }
+}
+impl<T: core::cmp::Eq, U> core::cmp::Eq for As<T, U> {}
+impl<T: core::cmp::PartialOrd, U> core::cmp::PartialOrd for As<T, U> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        self.value.partial_cmp(&other.value)
+    }
+}
+impl<T: core::cmp::Ord, U> core::cmp::Ord for As<T, U> {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.value.cmp(&other.value)
+    }
+}
+
+/// Digests any type `T` via its own implementation of [`Digestable`] trait
+pub struct Same;
+
+impl<T> DigestAs<T> for Same
+where
+    T: Digestable,
+{
+    fn digest_as<B: Buffer>(value: &T, encoder: encoding::EncodeValue<B>) {
+        value.unambiguously_encode(encoder)
+    }
+}
+
+/// Digests any bytestring that implements `impl AsRef<[u8]>`
+pub type Bytes = crate::Bytes<()>;
+
+impl<T> DigestAs<T> for Bytes
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    fn digest_as<B: Buffer>(value: &T, encoder: encoding::EncodeValue<B>) {
+        encoder.encode_leaf_value(value.as_ref())
+    }
+}
+
+impl<T, U> DigestAs<Option<T>> for Option<U>
+where
+    U: DigestAs<T>,
+{
+    fn digest_as<B: Buffer>(value: &Option<T>, encoder: encoding::EncodeValue<B>) {
+        value
+            .as_ref()
+            .map(As::<&T, &U>::new)
+            .unambiguously_encode(encoder)
+    }
+}
+
+impl<T1, T2, E1, E2> DigestAs<Result<T1, E1>> for Result<T2, E2>
+where
+    T2: DigestAs<T1>,
+    E2: DigestAs<E1>,
+{
+    fn digest_as<B: Buffer>(value: &Result<T1, E1>, encoder: encoding::EncodeValue<B>) {
+        value
+            .as_ref()
+            .map(As::<&T1, &T2>::new)
+            .map_err(As::<&E1, &E2>::new)
+            .unambiguously_encode(encoder)
+    }
+}
+
+impl<T, U> DigestAs<[T]> for [U]
+where
+    U: DigestAs<T>,
+{
+    fn digest_as<B: Buffer>(value: &[T], encoder: encoding::EncodeValue<B>) {
+        crate::unambiguously_encode_iter(encoder, value.iter().map(As::<&T, &U>::new))
+    }
+}
+
+impl<T, U, const N: usize> DigestAs<[T; N]> for [U; N]
+where
+    U: DigestAs<T>,
+{
+    fn digest_as<B: Buffer>(value: &[T; N], encoder: encoding::EncodeValue<B>) {
+        crate::unambiguously_encode_iter(encoder, value.iter().map(As::<&T, &U>::new))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T, U> DigestAs<alloc::vec::Vec<T>> for alloc::vec::Vec<U>
+where
+    U: DigestAs<T>,
+{
+    fn digest_as<B: Buffer>(value: &alloc::vec::Vec<T>, encoder: encoding::EncodeValue<B>) {
+        crate::unambiguously_encode_iter(encoder, value.iter().map(As::<&T, &U>::new))
+    }
+}
+
+impl<T, U> DigestAs<alloc::collections::LinkedList<T>> for alloc::collections::LinkedList<U>
+where
+    U: DigestAs<T>,
+{
+    fn digest_as<B: Buffer>(
+        value: &alloc::collections::LinkedList<T>,
+        encoder: encoding::EncodeValue<B>,
+    ) {
+        crate::unambiguously_encode_iter(encoder, value.iter().map(As::<&T, &U>::new))
+    }
+}
+impl<T, U> DigestAs<alloc::collections::VecDeque<T>> for alloc::collections::VecDeque<U>
+where
+    U: DigestAs<T>,
+{
+    fn digest_as<B: Buffer>(
+        value: &alloc::collections::VecDeque<T>,
+        encoder: encoding::EncodeValue<B>,
+    ) {
+        crate::unambiguously_encode_iter(encoder, value.iter().map(As::<&T, &U>::new))
+    }
+}
+impl<T, U> DigestAs<alloc::collections::BTreeSet<T>> for alloc::collections::BTreeSet<U>
+where
+    U: DigestAs<T>,
+{
+    fn digest_as<B: Buffer>(
+        value: &alloc::collections::BTreeSet<T>,
+        encoder: encoding::EncodeValue<B>,
+    ) {
+        crate::unambiguously_encode_iter(encoder, value.iter().map(As::<&T, &U>::new))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<K1, K2, V1, V2> DigestAs<alloc::collections::BTreeMap<K1, V1>>
+    for alloc::collections::BTreeMap<K2, V2>
+where
+    K2: DigestAs<K1>,
+    V2: DigestAs<V1>,
+{
+    fn digest_as<B: Buffer>(
+        value: &alloc::collections::BTreeMap<K1, V1>,
+        encoder: encoding::EncodeValue<B>,
+    ) {
+        crate::unambiguously_encode_iter(
+            encoder,
+            value
+                .iter()
+                .map(|(key, value)| (As::<&K1, &K2>::new(key), As::<&V1, &V2>::new(value))),
+        )
+    }
+}
+
+/// Digests `HashMap` by transforming it into `BTreeMap`
+#[cfg(feature = "std")]
+impl<K1, K2, V1, V2> DigestAs<std::collections::HashMap<K1, V1>>
+    for alloc::collections::BTreeMap<K2, V2>
+where
+    K2: DigestAs<K1>,
+    V2: DigestAs<V1>,
+    K1: core::cmp::Ord,
+{
+    fn digest_as<B: Buffer>(
+        value: &std::collections::HashMap<K1, V1>,
+        encoder: encoding::EncodeValue<B>,
+    ) {
+        let ordered_map = value
+            .iter()
+            .map(|(key, value)| (As::<&K1, &K2>::new(key), As::<&V1, &V2>::new(value)))
+            .collect::<alloc::collections::BTreeMap<_, _>>();
+
+        // ordered map has deterministic order, so we can reproducibly hash it
+        ordered_map.unambiguously_encode(encoder)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T, U> DigestAs<alloc::boxed::Box<T>> for alloc::boxed::Box<U>
+where
+    U: DigestAs<T>,
+{
+    fn digest_as<B: Buffer>(value: &alloc::boxed::Box<T>, encoder: encoding::EncodeValue<B>) {
+        U::digest_as(value, encoder)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T, U> DigestAs<alloc::rc::Rc<T>> for alloc::rc::Rc<U>
+where
+    U: DigestAs<T>,
+{
+    fn digest_as<B: Buffer>(value: &alloc::rc::Rc<T>, encoder: encoding::EncodeValue<B>) {
+        U::digest_as(value, encoder)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T, U> DigestAs<alloc::sync::Arc<T>> for alloc::sync::Arc<U>
+where
+    U: DigestAs<T>,
+{
+    fn digest_as<B: Buffer>(value: &alloc::sync::Arc<T>, encoder: encoding::EncodeValue<B>) {
+        U::digest_as(value, encoder)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a, T, U> DigestAs<alloc::borrow::Cow<'a, T>> for alloc::borrow::Cow<'a, U>
+where
+    U: DigestAs<T> + alloc::borrow::ToOwned,
+    T: alloc::borrow::ToOwned + ?Sized + 'a,
+{
+    fn digest_as<B: Buffer>(value: &alloc::borrow::Cow<'a, T>, encoder: encoding::EncodeValue<B>) {
+        U::digest_as(value.as_ref(), encoder)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a, T, U> DigestAs<alloc::borrow::Cow<'a, T>> for &'a U
+where
+    U: DigestAs<T>,
+    T: alloc::borrow::ToOwned + ?Sized + 'a,
+{
+    fn digest_as<B: Buffer>(value: &alloc::borrow::Cow<'a, T>, encoder: encoding::EncodeValue<B>) {
+        U::digest_as(value.as_ref(), encoder)
+    }
+}

--- a/udigest/src/as_.rs
+++ b/udigest/src/as_.rs
@@ -111,16 +111,16 @@ where
     }
 }
 
-impl<T1, T2, E1, E2> DigestAs<Result<T1, E1>> for Result<T2, E2>
+impl<T, TAs, E, EAs> DigestAs<Result<T, E>> for Result<TAs, EAs>
 where
-    T2: DigestAs<T1>,
-    E2: DigestAs<E1>,
+    TAs: DigestAs<T>,
+    EAs: DigestAs<E>,
 {
-    fn digest_as<B: Buffer>(value: &Result<T1, E1>, encoder: encoding::EncodeValue<B>) {
+    fn digest_as<B: Buffer>(value: &Result<T, E>, encoder: encoding::EncodeValue<B>) {
         value
             .as_ref()
-            .map(As::<&T1, &T2>::new)
-            .map_err(As::<&E1, &E2>::new)
+            .map(As::<&T, &TAs>::new)
+            .map_err(As::<&E, &EAs>::new)
             .unambiguously_encode(encoder)
     }
 }
@@ -190,41 +190,41 @@ where
 }
 
 #[cfg(feature = "alloc")]
-impl<K1, K2, V1, V2> DigestAs<alloc::collections::BTreeMap<K1, V1>>
-    for alloc::collections::BTreeMap<K2, V2>
+impl<K, KAs, V, VAs> DigestAs<alloc::collections::BTreeMap<K, V>>
+    for alloc::collections::BTreeMap<KAs, VAs>
 where
-    K2: DigestAs<K1>,
-    V2: DigestAs<V1>,
+    KAs: DigestAs<K>,
+    VAs: DigestAs<V>,
 {
     fn digest_as<B: Buffer>(
-        value: &alloc::collections::BTreeMap<K1, V1>,
+        value: &alloc::collections::BTreeMap<K, V>,
         encoder: encoding::EncodeValue<B>,
     ) {
         crate::unambiguously_encode_iter(
             encoder,
             value
                 .iter()
-                .map(|(key, value)| (As::<&K1, &K2>::new(key), As::<&V1, &V2>::new(value))),
+                .map(|(key, value)| (As::<&K, &KAs>::new(key), As::<&V, &VAs>::new(value))),
         )
     }
 }
 
 /// Digests `HashMap` by transforming it into `BTreeMap`
 #[cfg(feature = "std")]
-impl<K1, K2, V1, V2> DigestAs<std::collections::HashMap<K1, V1>>
-    for alloc::collections::BTreeMap<K2, V2>
+impl<K, KAs, V, VAs> DigestAs<std::collections::HashMap<K, V>>
+    for alloc::collections::BTreeMap<KAs, VAs>
 where
-    K2: DigestAs<K1>,
-    V2: DigestAs<V1>,
-    K1: core::cmp::Ord,
+    KAs: DigestAs<K>,
+    VAs: DigestAs<V>,
+    K: core::cmp::Ord,
 {
     fn digest_as<B: Buffer>(
-        value: &std::collections::HashMap<K1, V1>,
+        value: &std::collections::HashMap<K, V>,
         encoder: encoding::EncodeValue<B>,
     ) {
         let ordered_map = value
             .iter()
-            .map(|(key, value)| (As::<&K1, &K2>::new(key), As::<&V1, &V2>::new(value)))
+            .map(|(key, value)| (As::<&K, &KAs>::new(key), As::<&V, &VAs>::new(value)))
             .collect::<alloc::collections::BTreeMap<_, _>>();
 
         // ordered map has deterministic order, so we can reproducibly hash it

--- a/udigest/src/lib.rs
+++ b/udigest/src/lib.rs
@@ -480,10 +480,10 @@ impl<T: Digestable, E: Digestable> Digestable for Result<T, E> {
 
 macro_rules! digestable_tuple {
     ($($letter:ident),+) => {
-        impl<$($letter: Digestable),+> Digestable for ($($letter),+) {
+        impl<$($letter: Digestable),+> Digestable for ($($letter,)+) {
             fn unambiguously_encode<BUF: Buffer>(&self, encoder: encoding::EncodeValue<BUF>) {
                 #[allow(non_snake_case)]
-                let ($($letter),+) = self;
+                let ($($letter,)+) = self;
                 let mut list = encoder.encode_list();
                 $(
                     let item_encoder = list.add_item();
@@ -494,16 +494,23 @@ macro_rules! digestable_tuple {
     };
 }
 
-macro_rules! digestable_tuples {
-    ($letter:ident) => {};
-    ($letter:ident, $($others:ident),+) => {
-        digestable_tuple!($letter, $($others),+);
-        digestable_tuples!($($others),+);
-    }
-}
-
 // We support tuples with up to 16 elements
-digestable_tuples!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
+digestable_tuple!(A);
+digestable_tuple!(A, B);
+digestable_tuple!(A, B, C);
+digestable_tuple!(A, B, C, D);
+digestable_tuple!(A, B, C, D, E);
+digestable_tuple!(A, B, C, D, E, F);
+digestable_tuple!(A, B, C, D, E, F, G);
+digestable_tuple!(A, B, C, D, E, F, G, H);
+digestable_tuple!(A, B, C, D, E, F, G, H, I);
+digestable_tuple!(A, B, C, D, E, F, G, H, I, J);
+digestable_tuple!(A, B, C, D, E, F, G, H, I, J, K);
+digestable_tuple!(A, B, C, D, E, F, G, H, I, J, K, L);
+digestable_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M);
+digestable_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N);
+digestable_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
+digestable_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
 
 fn unambiguously_encode_iter<B: Buffer, T: Digestable>(
     encoder: encoding::EncodeValue<B>,

--- a/udigest/src/lib.rs
+++ b/udigest/src/lib.rs
@@ -308,7 +308,7 @@ impl<T: Digestable + ?Sized> Digestable for &T {
 /// Wrapper for a bytestring
 ///
 /// Wraps any bytestring that `impl AsRef<[u8]>` and provides [`Digestable`] trait implementation
-pub struct Bytes<T: ?Sized>(pub T);
+pub struct Bytes<T: ?Sized = [u8; 0]>(pub T);
 
 impl<T: AsRef<[u8]> + ?Sized> Digestable for Bytes<T> {
     fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {

--- a/udigest/src/lib.rs
+++ b/udigest/src/lib.rs
@@ -185,6 +185,47 @@ pub use encoding::Buffer;
 ///       todo!()
 ///   }
 ///   ```
+/// * `#[udigest(as = ...)]` \
+///   Tells to encode the field as another type `U`. Proc macro will use
+///   [`<U as DigestAs<FieldType>>::digest_as`](DigestAs) to encode this field.
+///
+///   It is similar to `#[udigest(with = ...)]` attribute described above which allows to specify
+///   a function which will be used to encode a field value. `#[udigest(as = ...)]` is designed for
+///   more complex use-cases. For instance, it can be used to digest a hash map:
+///
+///   ```rust
+///   #[derive(udigest::Digestable)]
+///   pub struct Attributes(
+///       #[udigest(as = std::collections::BTreeMap<_, udigest::Bytes>)]
+///       std::collections::HashMap<String, Vec<u8>>,
+///   );
+///   ```
+///
+///   When structure is digested, the hash map is converted into btree map. `_` in `BTreeMap<_, udigest::Bytes>`
+///   says that the key should be kept as it is: `String` string will be digested.
+///   `udigest::Bytes` indicates that the value `Vec<u8>` should be digested as bytes, not as
+///   list of u8 which would be a default behavior.
+///
+///   Similarly, if we have a field of type `Option<Vec<u8>>` and we want it to be encoded as
+///   bytes, we cannot use `#[udigest(as_bytes)]` as the field does not implement `AsRef<[u8]>`:
+///
+///   ```compile_fail
+///   #[derive(udigest::Digestable)]
+///   pub struct Data(
+///       #[udigest(as_bytes)]
+///       Option<Vec<u8>>,
+///   );
+///   ```
+///
+///   We can use `as` attribute instead:
+///   ```rust
+///   #[derive(udigest::Digestable)]
+///   pub struct Data(
+///       #[udigest(as = Option<udigest::Bytes>)]
+///       Option<Vec<u8>>,
+///   );
+///   ```
+///
 /// * `#[udigest(rename = "...")]` \
 ///   Specifies another name to use for the field. As field name gets mixed into the hash,
 ///   changing the field name will change the hash. Sometimes, it may be required to change

--- a/udigest/src/lib.rs
+++ b/udigest/src/lib.rs
@@ -202,7 +202,9 @@ pub use encoding::Buffer;
 ///   ```
 ///
 ///   When structure is digested, the hash map is converted into btree map. `_` in `BTreeMap<_, udigest::Bytes>`
-///   says that the key should be kept as it is: `String` string will be digested.
+///   says that the key should be kept as it is: `String` string will be digested. The macro
+///   replaces underscores (also called "infer types") with [`udigest::as_::Same`], which
+///   indicates that the same digestion rules should be used as for the original type.
 ///   `udigest::Bytes` indicates that the value `Vec<u8>` should be digested as bytes, not as
 ///   list of u8 which would be a default behavior.
 ///

--- a/udigest/src/lib.rs
+++ b/udigest/src/lib.rs
@@ -56,6 +56,8 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
 pub use encoding::Buffer;
 
@@ -204,6 +206,9 @@ pub mod encoding;
 #[cfg(feature = "inline-struct")]
 pub mod inline_struct;
 
+pub mod as_;
+pub use as_::DigestAs;
+
 /// Digests a structured `value` using fixed-output hash function (like sha2-256)
 #[cfg(feature = "digest")]
 pub fn hash<D: digest::Digest>(value: &impl Digestable) -> digest::Output<D> {
@@ -307,7 +312,7 @@ pub struct Bytes<T: ?Sized>(pub T);
 
 impl<T: AsRef<[u8]> + ?Sized> Digestable for Bytes<T> {
     fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
-        self.0.as_ref().unambiguously_encode(encoder)
+        encoder.encode_leaf_value(self.0.as_ref())
     }
 }
 

--- a/udigest/src/lib.rs
+++ b/udigest/src/lib.rs
@@ -203,7 +203,7 @@ pub use encoding::Buffer;
 ///
 ///   When structure is digested, the hash map is converted into btree map. `_` in `BTreeMap<_, udigest::Bytes>`
 ///   says that the key should be kept as it is: `String` string will be digested. The macro
-///   replaces underscores (also called "infer types") with [`udigest::as_::Same`], which
+///   replaces underscores (also called "infer types") with [`Same`](crate::as_::Same), which
 ///   indicates that the same digestion rules should be used as for the original type.
 ///   `udigest::Bytes` indicates that the value `Vec<u8>` should be digested as bytes, not as
 ///   list of u8 which would be a default behavior.

--- a/udigest/tests/common/mod.rs
+++ b/udigest/tests/common/mod.rs
@@ -1,0 +1,16 @@
+/// A buffer based on `Vec<u8>`. Writing to the buffer
+/// appends data to the vector
+pub struct VecBuf(pub Vec<u8>);
+
+impl udigest::encoding::Buffer for VecBuf {
+    fn write(&mut self, bytes: &[u8]) {
+        self.0.extend_from_slice(bytes)
+    }
+}
+
+/// Encodes digestable data into bytes
+pub fn encode_to_vec(x: &impl udigest::Digestable) -> Vec<u8> {
+    let mut buffer = VecBuf(vec![]);
+    x.unambiguously_encode(udigest::encoding::EncodeValue::new(&mut buffer));
+    buffer.0
+}

--- a/udigest/tests/common/mod.rs
+++ b/udigest/tests/common/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 /// A buffer based on `Vec<u8>`. Writing to the buffer
 /// appends data to the vector
 pub struct VecBuf(pub Vec<u8>);

--- a/udigest/tests/derive.rs
+++ b/udigest/tests/derive.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 #[derive(udigest::Digestable)]
 #[udigest(tag = concat!("udigest.example", ".v1"))]
 pub struct DigestableExample {
@@ -101,4 +103,12 @@ pub struct StructWithRefs<'a> {
     field3: &'a String,
     #[udigest(with = encoding::encode_bar)]
     field4: &'a Bar,
+}
+
+#[derive(udigest::Digestable)]
+pub struct OptionalBytes {
+    #[udigest(as = Option<udigest::Bytes>)]
+    field1: Option<Vec<u8>>,
+    #[udigest(as = std::collections::BTreeMap<_, udigest::Bytes>)]
+    hash_map: std::collections::HashMap<String, Vec<u8>>,
 }

--- a/udigest/tests/digest_as.rs
+++ b/udigest/tests/digest_as.rs
@@ -98,3 +98,35 @@ fn option() {
 
     assert_eq!(hex::encode(expected), hex::encode(actual));
 }
+
+#[test]
+fn array() {
+    #[derive(udigest::Digestable)]
+    struct Foo {
+        #[udigest(as = [udigest::Bytes; 5])]
+        bar: [Vec<u8>; 5],
+    }
+
+    impl Foo {
+        fn digest_expected(&self) -> impl udigest::Digestable + '_ {
+            udigest::inline_struct!({
+                bar: self.bar.each_ref().map(udigest::Bytes),
+            })
+        }
+    }
+
+    let foo = Foo {
+        bar: [
+            b"abcd".to_vec(),
+            b"aaaa".to_vec(),
+            b"..-..---.-..-".to_vec(),
+            b"bbbbbb".to_vec(),
+            b"finally".to_vec(),
+        ],
+    };
+
+    let expected = common::encode_to_vec(&foo.digest_expected());
+    let actual = common::encode_to_vec(&foo);
+
+    assert_eq!(hex::encode(expected), hex::encode(actual));
+}

--- a/udigest/tests/digest_as.rs
+++ b/udigest/tests/digest_as.rs
@@ -1,0 +1,100 @@
+mod common;
+
+#[test]
+fn list_of_bytestrings() {
+    #[derive(udigest::Digestable)]
+    struct Post {
+        title: String,
+        content: String,
+        #[udigest(as = Vec<udigest::Bytes>)]
+        images: Vec<Vec<u8>>,
+    }
+
+    impl Post {
+        fn digest_expected(&self) -> impl udigest::Digestable + '_ {
+            udigest::inline_struct!({
+                title: &self.title,
+                content: &self.content,
+                images: self.images
+                    .clone()
+                    .into_iter()
+                    .map(udigest::Bytes)
+                    .collect::<Vec<_>>(),
+            })
+        }
+    }
+
+    let post = Post {
+        title: "My first post!".into(),
+        content: "This is the first post I've ever written!".into(),
+        images: vec![b"some image".to_vec()],
+    };
+
+    let expected = common::encode_to_vec(&post.digest_expected());
+    let actual = common::encode_to_vec(&post);
+
+    assert_eq!(hex::encode(expected), hex::encode(actual));
+}
+
+#[test]
+fn hash_map() {
+    #[derive(udigest::Digestable)]
+    struct Attributes(
+        #[udigest(as = std::collections::BTreeMap<_, udigest::Bytes>)]
+        std::collections::HashMap<String, Vec<u8>>,
+    );
+
+    #[derive(udigest::Digestable)]
+    struct EncodingExpected(std::collections::BTreeMap<String, udigest::Bytes<Vec<u8>>>);
+
+    impl Attributes {
+        fn digest_expected(&self) -> impl udigest::Digestable + '_ {
+            let encoding = self
+                .0
+                .iter()
+                .map(|(k, v)| (k.clone(), udigest::Bytes(v.clone())))
+                .collect::<std::collections::BTreeMap<_, _>>();
+            EncodingExpected(encoding)
+        }
+    }
+
+    let attrs = Attributes(FromIterator::from_iter([
+        ("some_attr".to_string(), b"value1".to_vec()),
+        ("attr".to_string(), b"value2".to_vec()),
+        ("some_other_attr".to_string(), b"value3".to_vec()),
+    ]));
+
+    let expected = common::encode_to_vec(&attrs.digest_expected());
+    let actual = common::encode_to_vec(&attrs);
+
+    assert_eq!(hex::encode(expected), hex::encode(actual));
+}
+
+#[test]
+fn option() {
+    #[derive(udigest::Digestable)]
+    struct Person {
+        nickname: String,
+        #[udigest(as = Option<udigest::Bytes>)]
+        avatar: Option<Vec<u8>>,
+    }
+
+    impl Person {
+        fn digest_expected(&self) -> impl udigest::Digestable + '_ {
+            udigest::inline_struct!({
+                nickname: &self.nickname,
+                avatar: self.avatar.as_ref().map(udigest::Bytes)
+            })
+        }
+    }
+
+    let person = Person {
+        nickname: "c00l_name".to_string(),
+        avatar: Some(b"image".to_vec()),
+    };
+
+    let expected = common::encode_to_vec(&person.digest_expected());
+    let actual = common::encode_to_vec(&person);
+
+    assert_eq!(hex::encode(expected), hex::encode(actual));
+}

--- a/udigest/tests/encoding.rs
+++ b/udigest/tests/encoding.rs
@@ -1,14 +1,8 @@
 use udigest::encoding::*;
 
-/// A buffer based on `Vec<u8>`. Writing to the buffer
-/// appends data to the vector
-pub struct VecBuf(Vec<u8>);
+use common::VecBuf;
 
-impl udigest::encoding::Buffer for VecBuf {
-    fn write(&mut self, bytes: &[u8]) {
-        self.0.extend_from_slice(bytes)
-    }
-}
+mod common;
 
 macro_rules! concat_bytes_into_vec {
     ($($bytes:expr),*$(,)?) => {{


### PR DESCRIPTION
Add functionality to digest a field "as another type". E.g. hash map can be digested "as btree map" (implementation will convert hash map to btree map at runtime).

Other example is when we have `Option<Vec<u8>>`, which may be digested as `Option<udigest::Bytes>` which will encode vector as bytes (by default, it is digested as a list of u8, which results in a huge overhead)