### PR TITLE
Improve derive macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "basic-toml"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f2139706359229bfa8f19142ac1155b4b80beafb7a60471ac5dd109d4a19778"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,10 +76,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "keccak"
@@ -88,6 +109,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +130,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.193"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.193"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0652c533506ad7a2e353cce269330d6afd8bdfb6d75e0ace5b35aacbd7b9e9"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -144,6 +208,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8419ecd263363827c5730386f418715766f584e2f874d32c23c5b00bd9727e7e"
+dependencies = [
+ "basic-toml",
+ "glob",
+ "once_cell",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "termcolor",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +246,7 @@ dependencies = [
  "hex",
  "sha2",
  "sha3",
+ "trybuild",
  "udigest-derive",
 ]
 
@@ -181,3 +270,27 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link",
+]

--- a/udigest-derive/src/lib.rs
+++ b/udigest-derive/src/lib.rs
@@ -377,60 +377,76 @@ fn generate_impl_for_enum(
         }
     });
 
-    let match_expr = if !enum_variants.is_empty() {
-        let match_branches = enum_variants.iter().map(|v| {
-            let variant_name = &v.name;
-            let field_bindings = (0..v.fields.len())
-                .map(|i| syn::Ident::new(&format!("field{i}"), proc_macro2::Span::call_site()))
-                .collect::<Vec<_>>();
-            let pattern = match v.ty {
-                VariantType::Named => {
-                    let fields = v.fields.iter().zip(&field_bindings).map(|(f, binding)| {
-                        let field_name = &f.mem;
-                        quote! { #field_name: #binding }
-                    });
-                    quote! { {#(#fields),*} }
-                }
-                VariantType::Unnamed => {
-                    let fields = field_bindings.iter().map(|binding| {
-                        quote! {#binding}
-                    });
-                    quote! { (#(#fields),*) }
-                }
-                VariantType::Unit => {
-                    quote!()
-                }
-            };
+    let (match_expr, assertions) = if !enum_variants.is_empty() {
+        let (match_branches, assertions) = enum_variants
+            .iter()
+            .map(|v| {
+                let variant_name = &v.name;
+                let field_bindings = (0..v.fields.len())
+                    .map(|i| syn::Ident::new(&format!("field{i}"), proc_macro2::Span::call_site()))
+                    .collect::<Vec<_>>();
+                let pattern = match v.ty {
+                    VariantType::Named => {
+                        let fields = v.fields.iter().zip(&field_bindings).map(|(f, binding)| {
+                            let field_name = &f.mem;
+                            quote! { #field_name: #binding }
+                        });
+                        quote! { {#(#fields),*} }
+                    }
+                    VariantType::Unnamed => {
+                        let fields = field_bindings.iter().map(|binding| {
+                            quote! {#binding}
+                        });
+                        quote! { (#(#fields),*) }
+                    }
+                    VariantType::Unit => {
+                        quote!()
+                    }
+                };
 
-            let encode_fields = field_bindings.iter().zip(&v.fields).map(|(binding, f)| {
-                encode_field(
-                    &root_path,
-                    &encoder_var,
-                    &f.attrs,
-                    f.span,
-                    &f.stringify_field_name(),
-                    &f.ty,
-                    &binding,
-                )
-            });
+                let encode_fields = field_bindings.iter().zip(&v.fields).map(|(binding, f)| {
+                    encode_field(
+                        &root_path,
+                        &encoder_var,
+                        &f.attrs,
+                        f.span,
+                        &f.stringify_field_name(),
+                        &f.ty,
+                        &binding,
+                    )
+                });
 
-            let variant_name_str = variant_name.to_string();
-            quote_spanned! {variant_name.span() =>
-                #enum_name::#variant_name #pattern => {
-                    let mut #encoder_var = #encoder_var.with_variant(#variant_name_str);
-                    #(#encode_fields)*
-                }
-            }
-        });
-        quote! {
+                let field_names_duplicates_detection =
+                    assert_no_duplicates_in_enum_variant_field_names(
+                        &attrs.get_root_path(),
+                        &variant_name.to_string(),
+                        &v.fields,
+                    );
+
+                let variant_name_str = variant_name.to_string();
+                let match_branch = quote_spanned! {variant_name.span() =>
+                    #enum_name::#variant_name #pattern => {
+                        let mut #encoder_var = #encoder_var.with_variant(#variant_name_str);
+                        #(#encode_fields)*
+                    }
+                };
+                let assertion = field_names_duplicates_detection;
+                (match_branch, assertion)
+            })
+            .collect::<(Vec<_>, Vec<_>)>();
+        let match_expr = quote! {
             match self {
                 #(#match_branches)*
             }
-        }
+        };
+        (match_expr, assertions)
     } else {
-        quote! {
-            match *self {}
-        }
+        (
+            quote! {
+                match *self {}
+            },
+            vec![],
+        )
     };
 
     Ok(quote! {
@@ -444,6 +460,9 @@ fn generate_impl_for_enum(
                 #match_expr
             }
         }
+        const _: () = {
+            #(#assertions)*
+        };
     })
 }
 
@@ -480,6 +499,9 @@ fn generate_impl_for_struct(
         )
     });
 
+    let field_names_duplications_detection =
+        assert_no_duplicates_in_struct_field_names(&attrs.get_root_path(), struct_fields);
+
     Ok(quote! {
         impl #impl_generics #root_path::Digestable for #struct_name #ty_generics #where_clause {
             fn unambiguously_encode<B>(&self, encoder: #root_path::encoding::EncodeValue<B>)
@@ -492,6 +514,9 @@ fn generate_impl_for_struct(
                 #encoder_var.finish();
             }
         }
+        const _: () = {
+            #field_names_duplications_detection
+        };
     })
 }
 
@@ -619,6 +644,119 @@ fn encode_field(
             )
         }
     }
+}
+
+/// Produces a code which statically asserts that there's no duplicates in field name encodings
+///
+/// Takes a `root_path` (path to `udigest` lib), and list of fields
+fn assert_no_duplicates_in_struct_field_names(
+    root_path: &attrs::RootPath,
+    fields: &[Field],
+) -> proc_macro2::TokenStream {
+    assert_no_duplicates_in_field_names(root_path, fields, &|dup_a, dup_b| {
+        format!(
+            "fields `{}` and `{}` have identical name encoding",
+            dup_a, dup_b
+        )
+    })
+}
+
+/// Produces a code which statically asserts that there's no duplicates in field name encodings
+///
+/// Takes a `root_path` (path to `udigest` lib), and list of fields
+fn assert_no_duplicates_in_enum_variant_field_names(
+    root_path: &attrs::RootPath,
+    variant_name: &str,
+    fields: &[Field],
+) -> proc_macro2::TokenStream {
+    assert_no_duplicates_in_field_names(root_path, fields, &|dup_a, dup_b| {
+        format!(
+            "enum variant `{}` has fields `{}` and `{}` that have identical name encoding",
+            variant_name, dup_a, dup_b
+        )
+    })
+}
+
+/// Produces a code which statically asserts that there's no duplicates in field name encodings
+///
+/// Takes a `root_path` (path to `udigest` lib), and list of fields
+fn assert_no_duplicates_in_field_names(
+    root_path: &attrs::RootPath,
+    fields: &[Field],
+    error_msg: &dyn Fn(&str, &str) -> String,
+) -> proc_macro2::TokenStream {
+    if fields.iter().all(|f| f.attrs.rename.is_none()) {
+        // if no field was renamed, the check is not necessary: compiler won't allow
+        // fields with the same names
+        return proc_macro2::TokenStream::new();
+    }
+
+    // extract relevant info about fields
+    let fields = fields
+        .iter()
+        .map(|f| {
+            // span associated with the field
+            let span = f.span;
+            // name of the field as appears in field definition
+            let name = f.stringify_field_name();
+            // name of the field as appears in encoding
+            let encoding = f
+                .attrs
+                .rename
+                .as_ref()
+                .map(|attrs::Rename { value, .. }| quote_spanned!(span => #value))
+                .unwrap_or_else(|| quote_spanned!(span => #name));
+            (span, name, encoding)
+        })
+        .collect::<Vec<_>>();
+
+    assert_no_duplicates(root_path, &fields, error_msg)
+}
+
+/// Produces a code which statically asserts that there's no duplicates in statically-defined
+/// encodings (of field names, variant names, etc.)
+///
+/// Takes a `root_path` (path to `udigest` lib), set of `[(span, name, encoding)]`, and an error message
+/// formatter, and produces the code that statically asserts that there's no duplicates in this set of
+/// `encoding`.
+///
+/// `span` from the `set` is only used to produce a hint for compiler so it could identify a source of error
+/// more precisely (but compiler seems to ignore it for whatever reason at time of writing).
+///
+/// `name` from the `set` is only used to get an error message, by providing it to `error_msg` lambda.
+fn assert_no_duplicates(
+    root_path: &attrs::RootPath,
+    set: &[(proc_macro2::Span, String, proc_macro2::TokenStream)],
+    error_msg: &dyn Fn(&str, &str) -> String,
+) -> proc_macro2::TokenStream {
+    // for each (unordered) pair from the set, assert that their encoding isn't equal
+    let pairs = set
+        .iter()
+        .enumerate()
+        .flat_map(|(i, (span, a_name, a_name_encoding))| {
+            set[i + 1..]
+                .iter()
+                .map(move |(_, b_name, b_name_encoding)| {
+                    (
+                        *span,
+                        (a_name.clone(), a_name_encoding.clone()),
+                        (b_name, b_name_encoding),
+                    )
+                })
+        });
+    let assertions = pairs.map(
+        |(span, (a_name, a_name_encoding), (b_name, b_name_encoding))| {
+            let error_msg = error_msg(&a_name, b_name);
+            quote_spanned! {span => {
+                #root_path::const_assert_neq!(
+                    #a_name_encoding,
+                    #b_name_encoding,
+                    #error_msg,
+                );
+            }}
+        },
+    );
+    quote!(#(#assertions)*)
 }
 
 #[derive(Default)]

--- a/udigest-derive/src/lib.rs
+++ b/udigest-derive/src/lib.rs
@@ -122,6 +122,17 @@ fn process_field(root_path: &attrs::RootPath, index: u32, field: &syn::Field) ->
     };
     let mut field_attrs = FieldAttrs::default();
 
+    // FIXME: ideally, we want to use `field.span()`, however, that works awfully because
+    // `proc_macro::Span::join` is not stabilized. E.g. if field is `name: Vec<Something>`,
+    // `field.span()` will point to `name: Vec` instead of all field.
+    //
+    // We should change this once `Span::join` is stable.
+    let field_span = field
+        .ident
+        .as_ref()
+        .map(|i| i.span())
+        .unwrap_or_else(|| field.span());
+
     let mem = field
         .ident
         .clone()
@@ -191,7 +202,7 @@ fn process_field(root_path: &attrs::RootPath, index: u32, field: &syn::Field) ->
     }
 
     Ok(Field {
-        span: field.ty.span(),
+        span: field_span,
         attrs: field_attrs,
         mem,
         ty: field.ty.clone(),
@@ -465,7 +476,7 @@ fn generate_impl_for_struct(
             f.span,
             &f.stringify_field_name(),
             &f.ty,
-            &quote_spanned! {f.ty.span() => &self.#mem},
+            &quote_spanned! {f.span => &self.#mem},
         )
     });
 

--- a/udigest/Cargo.toml
+++ b/udigest/Cargo.toml
@@ -27,6 +27,8 @@ sha2 = "0.10"
 sha3 = "0.10"
 blake2 = "0.10"
 
+trybuild = "1"
+
 [features]
 default = ["digest", "std", "inline-struct"]
 
@@ -40,6 +42,10 @@ inline-struct = []
 [[test]]
 name = "derive"
 required-features = ["std", "derive", "digest"]
+
+[[test]]
+name = "derive_compile_fails"
+required-features = ["std", "derive"]
 
 [[test]]
 name = "deterministic_hash"

--- a/udigest/src/_macros.rs
+++ b/udigest/src/_macros.rs
@@ -1,0 +1,53 @@
+//! Hidden module that powers `Digestable` derive macro
+//!
+//! No stability guarantees for API in this module. It is not supposed to be used by anything else
+//! but Digestable derive macro.
+
+/// Compares two byte slices in constant time
+///
+/// Comparing slices via `==` operator is not stable yet
+pub const fn const_bytes_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+/// Given two bytestring or strings, asserts that they are not equal. Throws compilation error if they are.
+///
+/// Macro accepts three arguments: two strings/bytestrings to compare, and an error message. First two arguments
+/// can be both string, both bytestring, or one string and one bytestring in any order. They are coerced into
+/// bytestrings before comparison.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! const_assert_neq {
+    ($a:expr, $b:expr, $($msg:tt)+) => {
+        const _: () = {
+            // These unsafe block are sound because the pointer and length
+            // are obtained from a valid, existing slice (`$a` or `$b`).
+            let a_bytes: &[u8] = unsafe {
+                // Both `&str` and `&[u8]` have `.as_ptr()` and `.len()` as const fns.
+                core::slice::from_raw_parts($a.as_ptr(), $a.len())
+            };
+            let b_bytes: &[u8] = unsafe { core::slice::from_raw_parts($b.as_ptr(), $b.len()) };
+
+            if $crate::_macros::const_bytes_eq(a_bytes, b_bytes) {
+                panic!($($msg)+)
+            }
+        };
+    };
+}
+
+#[cfg(test)]
+mod test {
+    const ONE: &[u8] = b"thing";
+    const TWO: &str = "different";
+    crate::const_assert_neq!(ONE, TWO, "they are equal");
+}

--- a/udigest/src/lib.rs
+++ b/udigest/src/lib.rs
@@ -256,6 +256,9 @@ pub mod inline_struct;
 pub mod as_;
 pub use as_::DigestAs;
 
+#[doc(hidden)]
+pub mod _macros;
+
 /// Digests a structured `value` using fixed-output hash function (like sha2-256)
 #[cfg(feature = "digest")]
 pub fn hash<D: digest::Digest>(value: &impl Digestable) -> digest::Output<D> {

--- a/udigest/tests/derive_compile_fails.rs
+++ b/udigest/tests/derive_compile_fails.rs
@@ -1,0 +1,5 @@
+#[test]
+fn trybuild() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("./tests/derive_compile_fails/*.rs");
+}

--- a/udigest/tests/derive_compile_fails/field_not_digestable.rs
+++ b/udigest/tests/derive_compile_fails/field_not_digestable.rs
@@ -1,0 +1,26 @@
+// regular struct
+
+#[derive(udigest::Digestable)]
+struct Employee {
+    name: String,
+    competences: Vec<Competence>,
+}
+
+enum Competence {
+    Engineer,
+    Cryptographer,
+    Hardware,
+}
+
+// tuple struct
+
+#[derive(udigest::Digestable)]
+struct Stageur(Competence);
+
+// this will have a weird span in rendered error, but there's nothing we can do
+// at this time
+
+#[derive(udigest::Digestable)]
+struct PhdSummerStudent(Vec<Competence>);
+
+fn main() {}

--- a/udigest/tests/derive_compile_fails/field_not_digestable.stderr
+++ b/udigest/tests/derive_compile_fails/field_not_digestable.stderr
@@ -5,7 +5,7 @@ error[E0277]: the trait bound `Competence: Digestable` is not satisfied
   |          ------------------- required by a bound introduced by this call
 ...
 6 |     competences: Vec<Competence>,
-  |     ^^^^^^^^^^^^^^^^ the trait `Digestable` is not implemented for `Competence`
+  |     ^^^^^^^^^^^ the trait `Digestable` is not implemented for `Competence`
   |
   = help: the following other types implement trait `Digestable`:
             &T

--- a/udigest/tests/derive_compile_fails/field_not_digestable.stderr
+++ b/udigest/tests/derive_compile_fails/field_not_digestable.stderr
@@ -1,0 +1,59 @@
+error[E0277]: the trait bound `Competence: Digestable` is not satisfied
+ --> tests/derive_compile_fails/field_not_digestable.rs:6:5
+  |
+3 | #[derive(udigest::Digestable)]
+  |          ------------------- required by a bound introduced by this call
+...
+6 |     competences: Vec<Competence>,
+  |     ^^^^^^^^^^^^^^^^ the trait `Digestable` is not implemented for `Competence`
+  |
+  = help: the following other types implement trait `Digestable`:
+            &T
+            (A, B)
+            (A, B, C)
+            (A, B, C, D)
+            (A, B, C, D, E)
+            (A, B, C, D, E, F)
+            (A, B, C, D, E, F, G)
+            (A, B, C, D, E, F, G, H)
+          and $N others
+  = note: required for `Vec<Competence>` to implement `Digestable`
+
+error[E0277]: the trait bound `Competence: Digestable` is not satisfied
+  --> tests/derive_compile_fails/field_not_digestable.rs:18:16
+   |
+17 | #[derive(udigest::Digestable)]
+   |          ------------------- required by a bound introduced by this call
+18 | struct Stageur(Competence);
+   |                ^^^^^^^^^^ the trait `Digestable` is not implemented for `Competence`
+   |
+   = help: the following other types implement trait `Digestable`:
+             &T
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
+           and $N others
+
+error[E0277]: the trait bound `Competence: Digestable` is not satisfied
+  --> tests/derive_compile_fails/field_not_digestable.rs:24:25
+   |
+23 | #[derive(udigest::Digestable)]
+   |          ------------------- required by a bound introduced by this call
+24 | struct PhdSummerStudent(Vec<Competence>);
+   |                         ^^^ the trait `Digestable` is not implemented for `Competence`
+   |
+   = help: the following other types implement trait `Digestable`:
+             &T
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
+           and $N others
+   = note: required for `Vec<Competence>` to implement `Digestable`

--- a/udigest/tests/derive_compile_fails/two_fields_same_name.rs
+++ b/udigest/tests/derive_compile_fails/two_fields_same_name.rs
@@ -1,0 +1,67 @@
+// field name duplication may occur by renaming one of the fields:
+#[derive(udigest::Digestable)]
+struct Person1 {
+    name: String,
+    #[udigest(rename = "name")]
+    surname: String,
+}
+
+// ... by renaming one of the fields to byte string:
+#[derive(udigest::Digestable)]
+struct Person2 {
+    name: String,
+    #[udigest(rename = b"name")]
+    surname: String,
+}
+
+// or by renaming two fields:
+#[derive(udigest::Digestable)]
+struct Person3 {
+    #[udigest(rename = "name")]
+    first_name: String,
+    #[udigest(rename = "name")]
+    last_name: String,
+}
+
+// ... one of them may be a bytestring:
+#[derive(udigest::Digestable)]
+struct Person4 {
+    #[udigest(rename = b"name")]
+    first_name: String,
+    #[udigest(rename = "name")]
+    last_name: String,
+}
+#[derive(udigest::Digestable)]
+struct Person5 {
+    #[udigest(rename = "name")]
+    first_name: String,
+    #[udigest(rename = b"name")]
+    last_name: String,
+}
+
+// or they both can be a bytestring
+#[derive(udigest::Digestable)]
+struct Person6 {
+    #[udigest(rename = b"name")]
+    first_name: String,
+    #[udigest(rename = b"name")]
+    last_name: String,
+}
+
+// in enum:
+#[derive(udigest::Digestable)]
+enum Shape {
+    Circle {
+        r: u16,
+    },
+    Rect {
+        w: u16,
+        #[udigest(rename = "w")]
+        h: u16,
+    },
+    Square {
+        w: u16,
+    },
+}
+
+fn main() {}

--- a/udigest/tests/derive_compile_fails/two_fields_same_name.stderr
+++ b/udigest/tests/derive_compile_fails/two_fields_same_name.stderr
@@ -1,0 +1,55 @@
+error[E0080]: evaluation panicked: fields `name` and `surname` have identical name encoding
+ --> tests/derive_compile_fails/two_fields_same_name.rs:2:10
+  |
+2 | #[derive(udigest::Digestable)]
+  |          ^^^^^^^^^^^^^^^^^^^ evaluation of `_::_` failed here
+  |
+  = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the derive macro `udigest::Digestable` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation panicked: fields `name` and `surname` have identical name encoding
+  --> tests/derive_compile_fails/two_fields_same_name.rs:10:10
+   |
+10 | #[derive(udigest::Digestable)]
+   |          ^^^^^^^^^^^^^^^^^^^ evaluation of `_::_` failed here
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the derive macro `udigest::Digestable` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation panicked: fields `first_name` and `last_name` have identical name encoding
+  --> tests/derive_compile_fails/two_fields_same_name.rs:18:10
+   |
+18 | #[derive(udigest::Digestable)]
+   |          ^^^^^^^^^^^^^^^^^^^ evaluation of `_::_` failed here
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the derive macro `udigest::Digestable` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation panicked: fields `first_name` and `last_name` have identical name encoding
+  --> tests/derive_compile_fails/two_fields_same_name.rs:27:10
+   |
+27 | #[derive(udigest::Digestable)]
+   |          ^^^^^^^^^^^^^^^^^^^ evaluation of `_::_` failed here
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the derive macro `udigest::Digestable` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation panicked: fields `first_name` and `last_name` have identical name encoding
+  --> tests/derive_compile_fails/two_fields_same_name.rs:34:10
+   |
+34 | #[derive(udigest::Digestable)]
+   |          ^^^^^^^^^^^^^^^^^^^ evaluation of `_::_` failed here
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the derive macro `udigest::Digestable` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation panicked: fields `first_name` and `last_name` have identical name encoding
+  --> tests/derive_compile_fails/two_fields_same_name.rs:43:10
+   |
+43 | #[derive(udigest::Digestable)]
+   |          ^^^^^^^^^^^^^^^^^^^ evaluation of `_::_` failed here
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the derive macro `udigest::Digestable` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation panicked: enum variant `Rect` has fields `w` and `h` that have identical name encoding
+  --> tests/derive_compile_fails/two_fields_same_name.rs:52:10
+   |
+52 | #[derive(udigest::Digestable)]
+   |          ^^^^^^^^^^^^^^^^^^^ evaluation of `_::_` failed here
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the derive macro `udigest::Digestable` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Changes:

1. Add tests that misusing derive macro leads to specific error messages (see 1st commit) \
  This helps us refining error messages in typical cases, and detecting when those error messages are accidentally changed
2. Improve errors a bit (see 2nd commit) \
  Due to `proc_macro::Span::join` being unstable, `field.span()` returns truncated span in certain cases, which leads to a bit off error messages.
  E.g. this code:
   ```rust
   #[derive(udigest::Digestable)]
   struct Employee {
       name: String,
       competences: Vec<Competence>,
   }
   enum Competence { /* ... */ }
   ```
  
   Used to lead to this error: (notice that span terminates on `Vec` and doesn't do till the end of the type)
   ```text
   6 |     competences: Vec<Competence>,
     |     ^^^^^^^^^^^^^^^^ the trait `Digestable` is not implemented for `Competence`
   ```
  
   In structs with named fields, now error looks like this:
   ```text
   6 |     competences: Vec<Competence>,
     |     ^^^^^^^^^^^ the trait `Digestable` is not implemented for `Competence`
   ```
3. Prohibit fields that have the same encoding, e.g. this used to be allowed:
   ```rust
   #[derive(udigest::Digestable)]
   struct Person1 {
       name: String,
       #[udigest(rename = "name")]
       surname: String,
   }
   ```
   
   But now it returns an error
   ```text
   error[E0080]: evaluation panicked: fields `name` and `surname` have identical name encoding
    --> tests/derive_compile_fails/two_fields_same_name.rs:2:10
     |
   2 | #[derive(udigest::Digestable)]
     |          ^^^^^^^^^^^^^^^^^^^ evaluation of `_::_` failed here
     |
     = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the derive macro `udigest::Digestable` (in Nightly builds, run with -Z macro-backtrace for more info)
   ```

## On breaking change
This PR may break code in two scenarios:
1. Code has two fields that have the same name encoding
2. Code uses `#[udigest(rename = new_name)]` where `new_name` is neither `&str` nor `&[u8]` \
   New API only accepts statically-defined `&str` and `&[u8]` as a `new_name` (so we could perform static assertions). Old API used to accept anything that is `impl AsRef<[u8]>`, e.g. this would compile on old API and would not on new API:
   ```rust
   #[derive(udigest::Digestable)]
   struct Person {
       #[udigest(rename = Name)]
       name: String,
   }
   struct Name;
   impl AsRef<[u8]> for Name {
       fn as_ref(&self) -> &[u8] {
           b"name".as_slice()
       }
   }
   ```

It's acceptable to release breaking change under minor release if it addresses a bug. The fact that the derive macro used to accept fields with the same encoding is a bug.