### PR TITLE
Produce a compile error if `rename` attr is specified for enum variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "udigest"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "blake2",
  "digest",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "udigest-derive"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/udigest-derive/CHANGELOG.md
+++ b/udigest-derive/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.3.2
+* Produce compile error if `rename` attr is used on enum variant [#22] \
+  Refer to [issue #21] to get more details on this
+
+[#22]: https://github.com/LFDT-Lockness/udigest/pull/22
+[issue #21]: https://github.com/LFDT-Lockness/udigest/issues/21
+
 ## v0.3.1
 * Update links in crate settings [#14]
 

--- a/udigest-derive/Cargo.toml
+++ b/udigest-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udigest-derive"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 description = "Proc macro for `udigest` crate"
 license = "MIT OR Apache-2.0"

--- a/udigest-derive/src/lib.rs
+++ b/udigest-derive/src/lib.rs
@@ -66,7 +66,35 @@ fn process_enum(
         .variants
         .iter()
         .map(|v| {
+            let mut variant_attrs = EnumVariantAttrs::default();
+
+            for attr in &v.attrs {
+                let Some(attr) = parse_attribute(attr)? else {
+                    continue;
+                };
+                match attr {
+                    attrs::Attr::Rename(_) if variant_attrs.rename.is_some() => {
+                        return Err(Error::new(attr.kw_span(), "attribute is duplicated"));
+                    }
+                    attrs::Attr::Rename(attr) => {
+                        variant_attrs.rename = Some(attr);
+                    }
+                    attrs::Attr::Root(_)
+                    | attrs::Attr::Tag(_)
+                    | attrs::Attr::AsBytes(_)
+                    | attrs::Attr::Bound(_)
+                    | attrs::Attr::Skip(_)
+                    | attrs::Attr::With(_)
+                    | attrs::Attr::As(_) => {
+                        return Err(Error::new(
+                            attr.kw_span(),
+                            "not supported as attribute for enum variant",
+                        ));
+                    }
+                }
+            }
             Ok(Variant {
+                attrs: variant_attrs,
                 name: v.ident.clone(),
                 ty: match &v.fields {
                     syn::Fields::Named(_) => VariantType::Named,
@@ -366,61 +394,75 @@ fn generate_impl_for_enum(
         }
     });
 
-    let match_expr = if !enum_variants.is_empty() {
-        let match_branches = enum_variants.iter().map(|v| {
-            let variant_name = &v.name;
-            let field_bindings = (0..v.fields.len())
-                .map(|i| syn::Ident::new(&format!("field{i}"), proc_macro2::Span::call_site()))
-                .collect::<Vec<_>>();
-            let pattern = match v.ty {
-                VariantType::Named => {
-                    let fields = v.fields.iter().zip(&field_bindings).map(|(f, binding)| {
-                        let field_name = &f.mem;
-                        quote! { #field_name: #binding }
-                    });
-                    quote! { {#(#fields),*} }
-                }
-                VariantType::Unnamed => {
-                    let fields = field_bindings.iter().map(|binding| {
-                        quote! {#binding}
-                    });
-                    quote! { (#(#fields),*) }
-                }
-                VariantType::Unit => {
-                    quote!()
-                }
-            };
+    let match_expr =
+        if !enum_variants.is_empty() {
+            let match_branches = enum_variants.iter().map(|v| {
+                let variant_name = &v.name;
+                let span = variant_name.span();
+                let field_bindings = (0..v.fields.len())
+                    .map(|i| syn::Ident::new(&format!("field{i}"), span))
+                    .collect::<Vec<_>>();
+                let pattern = match v.ty {
+                    VariantType::Named => {
+                        let fields = v.fields.iter().zip(&field_bindings).map(|(f, binding)| {
+                            let field_name = &f.mem;
+                            quote_spanned! { span => #field_name: #binding }
+                        });
+                        quote_spanned! { span => {#(#fields),*} }
+                    }
+                    VariantType::Unnamed => {
+                        let fields = field_bindings.iter().map(|binding| {
+                            quote_spanned! { span => #binding }
+                        });
+                        quote_spanned! { span => (#(#fields),*) }
+                    }
+                    VariantType::Unit => {
+                        quote!()
+                    }
+                };
 
-            let encode_fields = field_bindings.iter().zip(&v.fields).map(|(binding, f)| {
-                encode_field(
-                    &root_path,
-                    &encoder_var,
-                    &f.attrs,
-                    f.span,
-                    &f.stringify_field_name(),
-                    &f.ty,
-                    &binding,
-                )
-            });
+                let encode_fields = field_bindings.iter().zip(&v.fields).map(|(binding, f)| {
+                    encode_field(
+                        &root_path,
+                        &encoder_var,
+                        &f.attrs,
+                        f.span,
+                        &f.stringify_field_name(),
+                        &f.ty,
+                        &binding,
+                    )
+                });
 
-            let variant_name_str = variant_name.to_string();
-            quote_spanned! {variant_name.span() =>
-                #enum_name::#variant_name #pattern => {
-                    let mut #encoder_var = #encoder_var.with_variant(#variant_name_str);
-                    #(#encode_fields)*
+                let variant_name_encoding = if let Some(attr) = &v.attrs.rename {
+                    return Err(Error::new(
+                        attr.rename.span(),
+                        "`rename` attribute is not supported on enum variants, and it has \
+                        been silently ignored in previous versions of the library without \
+                        any affect on enum hashing/encoding. Please, refer to issue #21 \
+                        for mitigation path: https://github.com/LFDT-Lockness/udigest/issues/21",
+                    ));
+                } else {
+                    let name = variant_name.to_string();
+                    quote_spanned!(span => #name)
+                };
+                Ok(quote_spanned!{span =>
+                    #enum_name::#variant_name #pattern => {
+                        let mut #encoder_var = #encoder_var.with_variant(#variant_name_encoding);
+                        #(#encode_fields)*
+                    }
+                })
+            }).collect::<Result<Vec<_>>>()?;
+
+            quote! {
+                match self {
+                    #(#match_branches)*
                 }
             }
-        });
-        quote! {
-            match self {
-                #(#match_branches)*
+        } else {
+            quote! {
+                match *self {}
             }
-        }
-    } else {
-        quote! {
-            match *self {}
-        }
-    };
+        };
 
     Ok(quote! {
         impl #impl_generics #root_path::Digestable for #enum_name #ty_generics #where_clause {
@@ -639,6 +681,11 @@ struct FieldAttrs {
     as_: Option<attrs::As>,
 }
 
+#[derive(Default)]
+struct EnumVariantAttrs {
+    rename: Option<attrs::Rename>,
+}
+
 struct Field {
     span: proc_macro2::Span,
     attrs: FieldAttrs,
@@ -656,6 +703,7 @@ impl Field {
 }
 
 struct Variant {
+    attrs: EnumVariantAttrs,
     name: syn::Ident,
     fields: Vec<Field>,
     ty: VariantType,

--- a/udigest-derive/src/lib.rs
+++ b/udigest-derive/src/lib.rs
@@ -394,13 +394,20 @@ fn generate_impl_for_enum(
         }
     });
 
-    let match_expr =
-        if !enum_variants.is_empty() {
-            let match_branches = enum_variants.iter().map(|v| {
+    let match_expr = if !enum_variants.is_empty() {
+        let match_branches = enum_variants
+            .iter()
+            .map(|v| {
                 let variant_name = &v.name;
                 let span = variant_name.span();
-                let field_bindings = (0..v.fields.len())
-                    .map(|i| syn::Ident::new(&format!("field{i}"), span))
+                let field_bindings = v
+                    .fields
+                    .iter()
+                    .enumerate()
+                    .map(|(i, f)| {
+                        let prefix = if f.attrs.skip.is_some() { "_" } else { "" };
+                        syn::Ident::new(&format!("{prefix}field{i}"), span)
+                    })
                     .collect::<Vec<_>>();
                 let pattern = match v.ty {
                     VariantType::Named => {
@@ -445,24 +452,25 @@ fn generate_impl_for_enum(
                     let name = variant_name.to_string();
                     quote_spanned!(span => #name)
                 };
-                Ok(quote_spanned!{span =>
+                Ok(quote_spanned! {span =>
                     #enum_name::#variant_name #pattern => {
                         let mut #encoder_var = #encoder_var.with_variant(#variant_name_encoding);
                         #(#encode_fields)*
                     }
                 })
-            }).collect::<Result<Vec<_>>>()?;
+            })
+            .collect::<Result<Vec<_>>>()?;
 
-            quote! {
-                match self {
-                    #(#match_branches)*
-                }
+        quote! {
+            match self {
+                #(#match_branches)*
             }
-        } else {
-            quote! {
-                match *self {}
-            }
-        };
+        }
+    } else {
+        quote! {
+            match *self {}
+        }
+    };
 
     Ok(quote! {
         impl #impl_generics #root_path::Digestable for #enum_name #ty_generics #where_clause {

--- a/udigest/CHANGELOG.md
+++ b/udigest/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.2.4
+* Produce compile error if `rename` attr is used on enum variant [#22] \
+  Refer to [issue #21] to get more details on this
+
+[#22]: https://github.com/LFDT-Lockness/udigest/pull/22
+[issue #21]: https://github.com/LFDT-Lockness/udigest/issues/21
+
 ## v0.2.3
 * Relax bounds in `DigestAs` implementations: allow `?Sized` types [#18]
 * Implement `Digestable` for `core::convert::Infallible` (a.k.a. Never type) [#19]

--- a/udigest/Cargo.toml
+++ b/udigest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udigest"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 license = "MIT OR Apache-2.0"
 description = "Unambiguously digest structured data"
@@ -18,7 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 digest = { version = "0.10", default-features = false, optional = true }
 
-udigest-derive = { version = "0.3", path = "../udigest-derive", optional = true }
+udigest-derive = { version = "=0.3.2", path = "../udigest-derive", optional = true }
 
 [dev-dependencies]
 hex = "0.4"


### PR DESCRIPTION
See #21 to understand the context.

As result, following code:

```rust
#[derive(udigest::Digestable)]
enum Shape {
    Circle {
        r: u16,
    },
    #[udigest(rename = "Rectangular")]
    Rect {
        w: u16,
        h: u16,
    },
}
```

produces this error:

```text
error: `rename` attribute is not supported on enum variants, and it has been silently ignored in previous versions of the library without any affect on enum hashing/encoding. Please, refer to issue #21 for mitigation path: https://github.com/LFDT-Lockness/udigest/issues/21
  --> udigest/examples/derivation.rs:14:15
   |
14 |     #[udigest(rename = "Rectangular")]
   |               ^^^^^^

error: could not compile `udigest` (example "derivation") due to 1 previous error
```