### PR TITLE
Add support of `rename` attr on enum variants

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,6 +77,20 @@ jobs:
         cache-on-failure: "true"
     - name: Run clippy
       run: cargo clippy --all-features --tests -- -D clippy::all
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v2
+      with:
+        cache-on-failure: "true"
+    - name: Install Miri
+      run: |
+        rustup toolchain install nightly --component miri
+        rustup override set nightly
+        cargo miri setup
+    - name: Run Miri
+      run: cargo miri test --all-features --lib -p udigest
   check-changelog:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "basic-toml"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f2139706359229bfa8f19142ac1155b4b80beafb7a60471ac5dd109d4a19778"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,10 +76,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "keccak"
@@ -88,6 +109,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +130,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.193"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.193"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0652c533506ad7a2e353cce269330d6afd8bdfb6d75e0ace5b35aacbd7b9e9"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -144,6 +208,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8419ecd263363827c5730386f418715766f584e2f874d32c23c5b00bd9727e7e"
+dependencies = [
+ "basic-toml",
+ "glob",
+ "once_cell",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "termcolor",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +246,7 @@ dependencies = [
  "hex",
  "sha2",
  "sha3",
+ "trybuild",
  "udigest-derive",
 ]
 
@@ -181,3 +270,27 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "udigest"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "blake2",
  "digest",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "udigest-derive"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/udigest-derive/CHANGELOG.md
+++ b/udigest-derive/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.4.0
+* `rename` attribute now works on enum variants as it always should have been
+* Derive macro produces an error if two fields or two enum variants have the same
+  name encoding
+* Improve errors readability
+
+See [PR #23](https://github.com/LFDT-Lockness/udigest/pull/23).
+
 ## v0.3.2
 * Produce compile error if `rename` attr is used on enum variant [#22] \
   Refer to [issue #21] to get more details on this

--- a/udigest-derive/Cargo.toml
+++ b/udigest-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udigest-derive"
-version = "0.3.2"
+version = "0.4.0"
 edition.workspace = true
 description = "Proc macro for `udigest` crate"
 license = "MIT OR Apache-2.0"

--- a/udigest-derive/src/lib.rs
+++ b/udigest-derive/src/lib.rs
@@ -405,8 +405,10 @@ fn generate_impl_for_enum(
         }
     });
 
-    let match_expr = if !enum_variants.is_empty() {
-        let match_branches = enum_variants
+    let variant_assertions =
+        assert_no_duplicates_in_enum_variant_names(&attrs.get_root_path(), enum_variants);
+    let (match_expr, fields_assertions) = if !enum_variants.is_empty() {
+        let (match_branches, assertions) = enum_variants
             .iter()
             .map(|v| {
                 let variant_name = &v.name;
@@ -457,24 +459,38 @@ fn generate_impl_for_enum(
                     let name = variant_name.to_string();
                     quote_spanned!(span => #name)
                 };
-                Ok(quote_spanned! {span =>
+
+                let field_names_duplicates_detection =
+                    assert_no_duplicates_in_enum_variant_field_names(
+                        &attrs.get_root_path(),
+                        &variant_name.to_string(),
+                        &v.fields,
+                    );
+
+                let match_branch = quote_spanned! {span =>
                     #enum_name::#variant_name #pattern => {
                         let mut #encoder_var = #encoder_var.with_variant(#variant_name_encoding);
                         #(#encode_fields)*
                     }
-                })
-            })
-            .collect::<Result<Vec<_>>>()?;
+                };
 
-        quote! {
+                Ok((match_branch, field_names_duplicates_detection))
+            })
+            .collect::<Result<(Vec<_>, Vec<_>)>>()?;
+
+        let match_expr = quote! {
             match self {
                 #(#match_branches)*
             }
-        }
+        };
+        (match_expr, assertions)
     } else {
-        quote! {
-            match *self {}
-        }
+        (
+            quote! {
+                match *self {}
+            },
+            vec![],
+        )
     };
 
     Ok(quote! {
@@ -488,6 +504,10 @@ fn generate_impl_for_enum(
                 #match_expr
             }
         }
+        const _: () = {
+            #variant_assertions
+            #(#fields_assertions)*
+        };
     })
 }
 
@@ -524,6 +544,9 @@ fn generate_impl_for_struct(
         )
     });
 
+    let field_names_duplications_detection =
+        assert_no_duplicates_in_struct_field_names(&attrs.get_root_path(), struct_fields);
+
     Ok(quote! {
         impl #impl_generics #root_path::Digestable for #struct_name #ty_generics #where_clause {
             fn unambiguously_encode<B>(&self, encoder: #root_path::encoding::EncodeValue<B>)
@@ -536,6 +559,9 @@ fn generate_impl_for_struct(
                 #encoder_var.finish();
             }
         }
+        const _: () = {
+            #field_names_duplications_detection
+        };
     })
 }
 
@@ -663,6 +689,153 @@ fn encode_field(
             )
         }
     }
+}
+
+/// Produces a code which statically asserts that there's no duplicates in field name encodings
+///
+/// Takes a `root_path` (path to `udigest` lib), and list of fields
+fn assert_no_duplicates_in_struct_field_names(
+    root_path: &attrs::RootPath,
+    fields: &[Field],
+) -> proc_macro2::TokenStream {
+    assert_no_duplicates_in_field_names(root_path, fields, &|dup_a, dup_b| {
+        format!(
+            "fields `{}` and `{}` have identical name encoding",
+            dup_a, dup_b
+        )
+    })
+}
+
+/// Produces a code which statically asserts that there's no duplicates in field name encodings
+///
+/// Takes a `root_path` (path to `udigest` lib), and list of fields
+fn assert_no_duplicates_in_enum_variant_field_names(
+    root_path: &attrs::RootPath,
+    variant_name: &str,
+    fields: &[Field],
+) -> proc_macro2::TokenStream {
+    assert_no_duplicates_in_field_names(root_path, fields, &|dup_a, dup_b| {
+        format!(
+            "enum variant `{}` has fields `{}` and `{}` that have identical name encoding",
+            variant_name, dup_a, dup_b
+        )
+    })
+}
+
+/// Produces a code which statically asserts that there's no duplicates in field name encodings
+///
+/// Takes a `root_path` (path to `udigest` lib), and list of fields
+fn assert_no_duplicates_in_field_names(
+    root_path: &attrs::RootPath,
+    fields: &[Field],
+    error_msg: &dyn Fn(&str, &str) -> String,
+) -> proc_macro2::TokenStream {
+    if fields.iter().all(|f| f.attrs.rename.is_none()) {
+        // if no field was renamed, the check is not necessary: compiler won't allow
+        // fields with the same names
+        return proc_macro2::TokenStream::new();
+    }
+
+    // extract relevant info about fields
+    let fields = fields
+        .iter()
+        .map(|f| {
+            // span associated with the field
+            let span = f.span;
+            // name of the field as appears in field definition
+            let name = f.stringify_field_name();
+            // name of the field as appears in encoding
+            let encoding = f
+                .attrs
+                .rename
+                .as_ref()
+                .map(|attrs::Rename { value, .. }| quote_spanned!(span => #value))
+                .unwrap_or_else(|| quote_spanned!(span => #name));
+            (span, name, encoding)
+        })
+        .collect::<Vec<_>>();
+
+    assert_no_duplicates(root_path, &fields, error_msg)
+}
+
+fn assert_no_duplicates_in_enum_variant_names(
+    root_path: &attrs::RootPath,
+    enum_variants: &[Variant],
+) -> proc_macro2::TokenStream {
+    if enum_variants.iter().all(|v| v.attrs.rename.is_none()) {
+        // if no variant was renamed, the check is not necessary: compiler won't allow
+        // variants with the same name
+        return proc_macro2::TokenStream::new();
+    }
+
+    let variants = enum_variants
+        .iter()
+        .map(|v| {
+            let span = v.name.span();
+            let name = v.name.to_string();
+            let encoding = v
+                .attrs
+                .rename
+                .as_ref()
+                .map(|attrs::Rename { value, .. }| quote_spanned!(span => #value))
+                .unwrap_or_else(|| quote_spanned!(span => #name));
+            (span, name, encoding)
+        })
+        .collect::<Vec<_>>();
+
+    assert_no_duplicates(root_path, &variants, &|dup_a, dup_b| {
+        format!("variants `{dup_a}` and `{dup_b}` have identical encoding")
+    })
+}
+
+/// Produces a code which statically asserts that there's no duplicates in statically-defined
+/// encodings (of field names, variant names, etc.)
+///
+/// Takes a `root_path` (path to `udigest` lib), set of `[(span, name, encoding)]`, and an error message
+/// formatter, and produces the code that statically asserts that there's no duplicates in this set of
+/// `encoding`.
+///
+/// `span` from the `set` is only used to produce a hint for compiler so it could identify a source of error
+/// more precisely (but compiler seems to ignore it for whatever reason at time of writing).
+///
+/// `name` from the `set` is only used to get an error message, by providing it to `error_msg` lambda.
+fn assert_no_duplicates(
+    root_path: &attrs::RootPath,
+    set: &[(proc_macro2::Span, String, proc_macro2::TokenStream)],
+    error_msg: &dyn Fn(&str, &str) -> String,
+) -> proc_macro2::TokenStream {
+    // for each (unordered) pair from the set, assert that their encoding isn't equal
+    let pairs = set
+        .iter()
+        .enumerate()
+        .flat_map(|(i, (span, a_name, a_name_encoding))| {
+            set[i + 1..]
+                .iter()
+                .map(move |(_, b_name, b_name_encoding)| {
+                    (
+                        *span,
+                        (a_name.clone(), a_name_encoding.clone()),
+                        (b_name, b_name_encoding),
+                    )
+                })
+        });
+    let assertions = pairs.map(
+        |(span, (a_name, a_name_encoding), (b_name, b_name_encoding))| {
+            let error_msg = error_msg(&a_name, b_name);
+            quote_spanned! {span => {
+                #[allow(non_upper_case_globals, dead_code)]
+                const has_unique_encoding: () = {
+                    if #root_path::const_eq!(
+                        #a_name_encoding,
+                        #b_name_encoding,
+                    ) {
+                        panic!(#error_msg);
+                    }
+                };
+            }}
+        },
+    );
+    quote!(#(#assertions)*)
 }
 
 #[derive(Default)]

--- a/udigest-derive/src/lib.rs
+++ b/udigest-derive/src/lib.rs
@@ -441,13 +441,7 @@ fn generate_impl_for_enum(
                 });
 
                 let variant_name_encoding = if let Some(attr) = &v.attrs.rename {
-                    return Err(Error::new(
-                        attr.rename.span(),
-                        "`rename` attribute is not supported on enum variants, and it has \
-                        been silently ignored in previous versions of the library without \
-                        any affect on enum hashing/encoding. Please, refer to issue #21 \
-                        for mitigation path: https://github.com/LFDT-Lockness/udigest/issues/21",
-                    ));
+                    quote::ToTokens::to_token_stream(&attr.value)
                 } else {
                     let name = variant_name.to_string();
                     quote_spanned!(span => #name)

--- a/udigest-derive/src/lib.rs
+++ b/udigest-derive/src/lib.rs
@@ -150,6 +150,17 @@ fn process_field(root_path: &attrs::RootPath, index: u32, field: &syn::Field) ->
     };
     let mut field_attrs = FieldAttrs::default();
 
+    // FIXME: ideally, we want to use `field.span()`, however, that works awfully because
+    // `proc_macro::Span::join` is not stabilized. E.g. if field is `name: Vec<Something>`,
+    // `field.span()` will point to `name: Vec` instead of all field.
+    //
+    // We should change this once `Span::join` is stable.
+    let field_span = field
+        .ident
+        .as_ref()
+        .map(|i| i.span())
+        .unwrap_or_else(|| field.span());
+
     let mem = field
         .ident
         .clone()
@@ -219,7 +230,7 @@ fn process_field(root_path: &attrs::RootPath, index: u32, field: &syn::Field) ->
     }
 
     Ok(Field {
-        span: field.ty.span(),
+        span: field_span,
         attrs: field_attrs,
         mem,
         ty: field.ty.clone(),
@@ -509,7 +520,7 @@ fn generate_impl_for_struct(
             f.span,
             &f.stringify_field_name(),
             &f.ty,
-            &quote_spanned! {f.ty.span() => &self.#mem},
+            &quote_spanned! {f.span => &self.#mem},
         )
     });
 

--- a/udigest/CHANGELOG.md
+++ b/udigest/CHANGELOG.md
@@ -1,3 +1,55 @@
+## v0.3.0
+* `rename` attribute is not ignored anymore on enum variants by `derive(udigest::Digestable)`
+
+  **Possibly breaking change**: `#[udigest(rename = ..)]` attribute on enum variant was silently
+  ignored by previous versions of the library (except `v0.2.4` which throws an error if this attr
+  is used). If you used this attr on enum variant, encoding of your enum **will be changed** once you
+  upgrade to this version.
+
+  If you need a stable encoding:
+  1. Upgrade to `v0.2.4` first and compile your project
+  2. If anywhere in the project you're using `rename` attribute on enum variant, derive macro will produce an error
+     1. For each such error, remove `rename` attribute as it has been silently ignored by the library anyways
+  3. Now you can upgrade to `v0.3.0` while preserving encoding format compatible with previous version of your application
+
+  This does not affect you if you haven't been using `rename` attribute on enum variant or you don't
+  care about stability of encoding between library versions.
+
+  Example of affected code:
+  ```rust
+  #[derive(udigest::Digestable)]
+  enum Shape {
+      #[udigest(rename = "Rectangular")] // this attr was silently ignored
+      Rect {
+          #[udigest(rename = "width")] // this attr IS NOT affected, it has always been taken into account
+          w: u16,
+          h: u16,
+      },
+  }
+  ```
+* Derive macro statically asserts that all fields and enum variant have unique encoding
+
+  For instance, this code:
+  ```rust
+  #[derive(udigest::Digestable)]
+  struct Person {
+      name: String,
+      #[udigest(rename = "name")]
+      surname: String,
+  }
+  ```
+
+  will now produce an error as two different fields have the same encoding.
+
+  **Possibly breaking change**: in previous versions of the library, `rename` attribute used
+  to accept any expression that implements `AsRef<[u8]>`. Now, since `AsRef` is not available
+  in `const` context, the attribute only accepts any const expressions producing a value of type:
+  `&str`, `&[u8]`, `[u8; N]`, or (if `alloc` feature is enabled) `String`, `Vec<u8>`, `Cow<str>`,
+  `Cow<[u8]>`.
+* Improve errors readability
+
+See [PR #23](https://github.com/LFDT-Lockness/udigest/pull/23).
+
 ## v0.2.4
 * Produce compile error if `rename` attr is used on enum variant [#22] \
   Refer to [issue #21] to get more details on this

--- a/udigest/Cargo.toml
+++ b/udigest/Cargo.toml
@@ -42,6 +42,10 @@ name = "derive"
 required-features = ["std", "derive", "digest"]
 
 [[test]]
+name = "derive_encoding"
+required-features = ["std", "derive", "digest"]
+
+[[test]]
 name = "deterministic_hash"
 required-features = ["derive", "digest"]
 

--- a/udigest/Cargo.toml
+++ b/udigest/Cargo.toml
@@ -27,6 +27,8 @@ sha2 = "0.10"
 sha3 = "0.10"
 blake2 = "0.10"
 
+trybuild = "1"
+
 [features]
 default = ["digest", "std", "inline-struct"]
 
@@ -44,6 +46,10 @@ required-features = ["std", "derive", "digest"]
 [[test]]
 name = "derive_encoding"
 required-features = ["std", "derive", "digest"]
+
+[[test]]
+name = "derive_compile_fails"
+required-features = ["std", "derive"]
 
 [[test]]
 name = "deterministic_hash"

--- a/udigest/Cargo.toml
+++ b/udigest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udigest"
-version = "0.2.4"
+version = "0.3.0"
 edition.workspace = true
 license = "MIT OR Apache-2.0"
 description = "Unambiguously digest structured data"
@@ -18,7 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 digest = { version = "0.10", default-features = false, optional = true }
 
-udigest-derive = { version = "=0.3.2", path = "../udigest-derive", optional = true }
+udigest-derive = { version = "=0.4.0", path = "../udigest-derive", optional = true }
 
 [dev-dependencies]
 hex = "0.4"

--- a/udigest/src/_macros.rs
+++ b/udigest/src/_macros.rs
@@ -29,7 +29,8 @@ macro_rules! const_eq {
         let a = $a;
         let b = $b;
 
-        // macro can only be called on str, String, slice of bytes, array of bytes, or Vec of bytes
+        // macro can only be called on str, String, slice of bytes, array of bytes, Vec of bytes, Cow<str>,
+        // or Cow<[u8]>
         $crate::_macros::can_be_compared_in_const(&a);
         $crate::_macros::can_be_compared_in_const(&b);
 
@@ -81,4 +82,26 @@ mod test {
         assert!(TRUE);
         assert!(!FALSE);
     };
+}
+
+// Since `const_eq` macro uses unsafe code, we run some tests via miri to make sure there's no
+// UB.
+#[cfg(all(test, miri))]
+mod miri_test {
+    use alloc::borrow::ToOwned;
+    use core::hint::black_box;
+
+    #[test]
+    fn comparisons() {
+        let a = "one";
+        let b = "two";
+
+        // compare two static str
+        assert!(const_eq!(black_box(a), black_box(a)));
+        assert!(!const_eq!(black_box(a), black_box(b)));
+        // compare static str and a string
+        assert!(!const_eq!(black_box(a), "three".to_owned()));
+        // compare vec and string
+        assert!(!const_eq!("one".as_bytes().to_vec(), "two".to_owned()));
+    }
 }

--- a/udigest/src/_macros.rs
+++ b/udigest/src/_macros.rs
@@ -1,0 +1,84 @@
+//! Hidden module that powers `Digestable` derive macro
+//!
+//! No stability guarantees for API in this module. It is not supposed to be used by anything else
+//! but Digestable derive macro.
+
+/// Compares two byte slices in `const` expression
+///
+/// Comparing slices via `==` operator is not stable yet
+pub const fn const_bytes_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+/// Given two arguments, both of which can be either string or slice of bytes, returns `true` if they are equal.
+/// Works in `const` expressions.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! const_eq {
+    ($a:expr, $b:expr $(,)?) => {{
+        let a = $a;
+        let b = $b;
+
+        // macro can only be called on str, String, slice of bytes, array of bytes, or Vec of bytes
+        $crate::_macros::can_be_compared_in_const(&a);
+        $crate::_macros::can_be_compared_in_const(&b);
+
+        // since `AsRef<[u8]>` is not available in `const` expressions, we use the hack below
+        // to cast to slice of bytes either string or a slice of bytes, both of which have
+        // `.as_ptr()` and `.len()` methods available in `const` context
+
+        // SAFETY: These unsafe block are sound because the pointer and length
+        // are obtained from a valid, existing slice or string (note that calls
+        // to `can_be_compared_in_const` guarantees that `a` and `b` are either
+        // str or slice of bytes)
+        let a_bytes: &[u8] = unsafe { core::slice::from_raw_parts(a.as_ptr(), a.len()) };
+        // SAFETY: see notice above
+        let b_bytes: &[u8] = unsafe { core::slice::from_raw_parts(b.as_ptr(), b.len()) };
+
+        $crate::_macros::const_bytes_eq(a_bytes, b_bytes)
+    }};
+}
+
+/// Marker which is implemented for types that can be compared by `const_eq` macro
+trait Comparable {}
+
+impl Comparable for str {}
+#[cfg(feature = "alloc")]
+impl Comparable for alloc::string::String {}
+impl Comparable for [u8] {}
+impl<const N: usize> Comparable for [u8; N] {}
+#[cfg(feature = "alloc")]
+impl Comparable for alloc::vec::Vec<u8> {}
+#[cfg(feature = "alloc")]
+impl Comparable for alloc::borrow::Cow<'_, str> {}
+#[cfg(feature = "alloc")]
+impl Comparable for alloc::borrow::Cow<'_, [u8]> {}
+impl<T: Comparable + ?Sized> Comparable for &T {}
+
+/// Statically asserts that `T` implements `Comparable` trait
+#[allow(private_bounds)]
+pub const fn can_be_compared_in_const<T: Comparable>(_: &T) {}
+
+#[cfg(test)]
+mod test {
+    const ONE: &[u8] = b"thing";
+    const TWO: &str = "different";
+
+    const TRUE: bool = const_eq!(ONE, ONE);
+    const FALSE: bool = const_eq!(ONE, TWO);
+    #[allow(clippy::assertions_on_constants)]
+    const _: () = {
+        assert!(TRUE);
+        assert!(!FALSE);
+    };
+}

--- a/udigest/src/encoding.rs
+++ b/udigest/src/encoding.rs
@@ -266,6 +266,13 @@ impl<'b, B: Buffer> EncodeValue<'b, B> {
         #[allow(clippy::expect_used)]
         EncodeEnum::new(self.buffer.take().expect("buffer must be available"))
     }
+
+    /// Encodes a value that implements [`Digestable`](crate::Digestable) trait
+    ///
+    /// Alias to `Digestable::unambiguously_encode(value, encoder)`
+    pub fn encode(self, value: &impl crate::Digestable) {
+        value.unambiguously_encode(self);
+    }
 }
 
 impl<'b, B: Buffer> Drop for EncodeValue<'b, B> {

--- a/udigest/src/lib.rs
+++ b/udigest/src/lib.rs
@@ -256,6 +256,9 @@ pub mod inline_struct;
 pub mod as_;
 pub use as_::DigestAs;
 
+#[doc(hidden)]
+pub mod _macros;
+
 /// Digests a structured `value` using fixed-output hash function (like sha2-256)
 #[cfg(feature = "digest")]
 pub fn hash<D: digest::Digest>(value: &impl Digestable) -> digest::Output<D> {

--- a/udigest/tests/common/mod.rs
+++ b/udigest/tests/common/mod.rs
@@ -2,6 +2,7 @@
 
 /// A buffer based on `Vec<u8>`. Writing to the buffer
 /// appends data to the vector
+#[derive(Default)]
 pub struct VecBuf(pub Vec<u8>);
 
 impl udigest::encoding::Buffer for VecBuf {

--- a/udigest/tests/derive.rs
+++ b/udigest/tests/derive.rs
@@ -1,3 +1,5 @@
+//! In this test, we use proc macro in all possible combinations to make sure they compile
+
 #![allow(dead_code)]
 
 #[derive(udigest::Digestable)]
@@ -32,6 +34,7 @@ pub struct Empty;
 
 #[derive(udigest::Digestable)]
 pub enum EnumExample {
+    #[udigest(rename = "Variant0")]
     Variant1 {
         integer: i32,
         #[udigest(rename = 2_u32.to_be_bytes())]

--- a/udigest/tests/derive_compile_fails.rs
+++ b/udigest/tests/derive_compile_fails.rs
@@ -1,0 +1,5 @@
+#[test]
+fn trybuild() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("./tests/derive_compile_fails/*.rs");
+}

--- a/udigest/tests/derive_compile_fails/field_not_digestable.rs
+++ b/udigest/tests/derive_compile_fails/field_not_digestable.rs
@@ -1,0 +1,26 @@
+// regular struct
+
+#[derive(udigest::Digestable)]
+struct Employee {
+    name: String,
+    competences: Vec<Competence>,
+}
+
+enum Competence {
+    Engineer,
+    Cryptographer,
+    Hardware,
+}
+
+// tuple struct
+
+#[derive(udigest::Digestable)]
+struct Stageur(Competence);
+
+// this will have a weird span in rendered error, but there's nothing we can do
+// at this time
+
+#[derive(udigest::Digestable)]
+struct PhdSummerStudent(Vec<Competence>);
+
+fn main() {}

--- a/udigest/tests/derive_compile_fails/field_not_digestable.stderr
+++ b/udigest/tests/derive_compile_fails/field_not_digestable.stderr
@@ -5,7 +5,7 @@ error[E0277]: the trait bound `Competence: Digestable` is not satisfied
   |          ------------------- required by a bound introduced by this call
 ...
 6 |     competences: Vec<Competence>,
-  |     ^^^^^^^^^^^^^^^^ the trait `Digestable` is not implemented for `Competence`
+  |     ^^^^^^^^^^^ the trait `Digestable` is not implemented for `Competence`
   |
   = help: the following other types implement trait `Digestable`:
             &T

--- a/udigest/tests/derive_compile_fails/field_not_digestable.stderr
+++ b/udigest/tests/derive_compile_fails/field_not_digestable.stderr
@@ -1,0 +1,59 @@
+error[E0277]: the trait bound `Competence: Digestable` is not satisfied
+ --> tests/derive_compile_fails/field_not_digestable.rs:6:5
+  |
+3 | #[derive(udigest::Digestable)]
+  |          ------------------- required by a bound introduced by this call
+...
+6 |     competences: Vec<Competence>,
+  |     ^^^^^^^^^^^^^^^^ the trait `Digestable` is not implemented for `Competence`
+  |
+  = help: the following other types implement trait `Digestable`:
+            &T
+            (A, B)
+            (A, B, C)
+            (A, B, C, D)
+            (A, B, C, D, E)
+            (A, B, C, D, E, F)
+            (A, B, C, D, E, F, G)
+            (A, B, C, D, E, F, G, H)
+          and $N others
+  = note: required for `Vec<Competence>` to implement `Digestable`
+
+error[E0277]: the trait bound `Competence: Digestable` is not satisfied
+  --> tests/derive_compile_fails/field_not_digestable.rs:18:16
+   |
+17 | #[derive(udigest::Digestable)]
+   |          ------------------- required by a bound introduced by this call
+18 | struct Stageur(Competence);
+   |                ^^^^^^^^^^ the trait `Digestable` is not implemented for `Competence`
+   |
+   = help: the following other types implement trait `Digestable`:
+             &T
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
+           and $N others
+
+error[E0277]: the trait bound `Competence: Digestable` is not satisfied
+  --> tests/derive_compile_fails/field_not_digestable.rs:24:25
+   |
+23 | #[derive(udigest::Digestable)]
+   |          ------------------- required by a bound introduced by this call
+24 | struct PhdSummerStudent(Vec<Competence>);
+   |                         ^^^ the trait `Digestable` is not implemented for `Competence`
+   |
+   = help: the following other types implement trait `Digestable`:
+             &T
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
+           and $N others
+   = note: required for `Vec<Competence>` to implement `Digestable`

--- a/udigest/tests/derive_compile_fails/two_fields_same_name.rs
+++ b/udigest/tests/derive_compile_fails/two_fields_same_name.rs
@@ -1,0 +1,67 @@
+// field name duplication may occur by renaming one of the fields:
+#[derive(udigest::Digestable)]
+struct Person1 {
+    name: String,
+    #[udigest(rename = "name")]
+    surname: String,
+}
+
+// ... by renaming one of the fields to byte string:
+#[derive(udigest::Digestable)]
+struct Person2 {
+    name: String,
+    #[udigest(rename = b"name")]
+    surname: String,
+}
+
+// or by renaming two fields:
+#[derive(udigest::Digestable)]
+struct Person3 {
+    #[udigest(rename = "name")]
+    first_name: String,
+    #[udigest(rename = "name")]
+    last_name: String,
+}
+
+// ... one of them may be a bytestring:
+#[derive(udigest::Digestable)]
+struct Person4 {
+    #[udigest(rename = b"name")]
+    first_name: String,
+    #[udigest(rename = "name")]
+    last_name: String,
+}
+#[derive(udigest::Digestable)]
+struct Person5 {
+    #[udigest(rename = "name")]
+    first_name: String,
+    #[udigest(rename = b"name")]
+    last_name: String,
+}
+
+// or they both can be a bytestring
+#[derive(udigest::Digestable)]
+struct Person6 {
+    #[udigest(rename = b"name")]
+    first_name: String,
+    #[udigest(rename = b"name")]
+    last_name: String,
+}
+
+// in enum:
+#[derive(udigest::Digestable)]
+enum Shape {
+    Circle {
+        r: u16,
+    },
+    Rect {
+        w: u16,
+        #[udigest(rename = "w")]
+        h: u16,
+    },
+    Square {
+        w: u16,
+    },
+}
+
+fn main() {}

--- a/udigest/tests/derive_compile_fails/two_fields_same_name.stderr
+++ b/udigest/tests/derive_compile_fails/two_fields_same_name.stderr
@@ -1,0 +1,41 @@
+error[E0080]: evaluation panicked: fields `name` and `surname` have identical name encoding
+ --> tests/derive_compile_fails/two_fields_same_name.rs:4:5
+  |
+4 |     name: String,
+  |     ^^^^ evaluation of `_::has_unique_encoding` failed here
+
+error[E0080]: evaluation panicked: fields `name` and `surname` have identical name encoding
+  --> tests/derive_compile_fails/two_fields_same_name.rs:12:5
+   |
+12 |     name: String,
+   |     ^^^^ evaluation of `_::has_unique_encoding` failed here
+
+error[E0080]: evaluation panicked: fields `first_name` and `last_name` have identical name encoding
+  --> tests/derive_compile_fails/two_fields_same_name.rs:21:5
+   |
+21 |     first_name: String,
+   |     ^^^^^^^^^^ evaluation of `_::has_unique_encoding` failed here
+
+error[E0080]: evaluation panicked: fields `first_name` and `last_name` have identical name encoding
+  --> tests/derive_compile_fails/two_fields_same_name.rs:30:5
+   |
+30 |     first_name: String,
+   |     ^^^^^^^^^^ evaluation of `_::has_unique_encoding` failed here
+
+error[E0080]: evaluation panicked: fields `first_name` and `last_name` have identical name encoding
+  --> tests/derive_compile_fails/two_fields_same_name.rs:37:5
+   |
+37 |     first_name: String,
+   |     ^^^^^^^^^^ evaluation of `_::has_unique_encoding` failed here
+
+error[E0080]: evaluation panicked: fields `first_name` and `last_name` have identical name encoding
+  --> tests/derive_compile_fails/two_fields_same_name.rs:46:5
+   |
+46 |     first_name: String,
+   |     ^^^^^^^^^^ evaluation of `_::has_unique_encoding` failed here
+
+error[E0080]: evaluation panicked: enum variant `Rect` has fields `w` and `h` that have identical name encoding
+  --> tests/derive_compile_fails/two_fields_same_name.rs:58:9
+   |
+58 |         w: u16,
+   |         ^ evaluation of `_::has_unique_encoding` failed here

--- a/udigest/tests/derive_compile_fails/two_variants_same_name.rs
+++ b/udigest/tests/derive_compile_fails/two_variants_same_name.rs
@@ -1,0 +1,93 @@
+// variant name duplication may occur by renaming one of the variants:
+#[derive(udigest::Digestable)]
+enum Employee1 {
+    Dev {
+        stack: String,
+    },
+    #[udigest(rename = "Dev")]
+    Cryptographer {
+        field: String,
+    },
+    Hr {
+        head: bool,
+    },
+}
+
+// ... by renaming one of the variants to byte string:
+#[derive(udigest::Digestable)]
+enum Employee2 {
+    Dev {
+        stack: String,
+    },
+    #[udigest(rename = b"Dev")]
+    Cryptographer {
+        field: String,
+    },
+    Hr {
+        head: bool,
+    },
+}
+
+// or by renaming two variants:
+#[derive(udigest::Digestable)]
+enum Employee3 {
+    #[udigest(rename = "SomethingElse")]
+    Dev {
+        stack: String,
+    },
+    #[udigest(rename = "SomethingElse")]
+    Cryptographer {
+        field: String,
+    },
+    Hr {
+        head: bool,
+    },
+}
+
+// ... one of them may be a bytestring:
+#[derive(udigest::Digestable)]
+enum Employee4 {
+    #[udigest(rename = "SomethingElse")]
+    Dev {
+        stack: String,
+    },
+    #[udigest(rename = b"SomethingElse")]
+    Cryptographer {
+        field: String,
+    },
+    Hr {
+        head: bool,
+    },
+}
+#[derive(udigest::Digestable)]
+enum Employee5 {
+    #[udigest(rename = b"SomethingElse")]
+    Dev {
+        stack: String,
+    },
+    #[udigest(rename = "SomethingElse")]
+    Cryptographer {
+        field: String,
+    },
+    Hr {
+        head: bool,
+    },
+}
+
+// or they both can be a bytestring
+#[derive(udigest::Digestable)]
+enum Employee6 {
+    #[udigest(rename = b"SomethingElse")]
+    Dev {
+        stack: String,
+    },
+    #[udigest(rename = b"SomethingElse")]
+    Cryptographer {
+        field: String,
+    },
+    Hr {
+        head: bool,
+    },
+}
+
+fn main() {}

--- a/udigest/tests/derive_compile_fails/two_variants_same_name.stderr
+++ b/udigest/tests/derive_compile_fails/two_variants_same_name.stderr
@@ -1,0 +1,35 @@
+error[E0080]: evaluation panicked: variants `Dev` and `Cryptographer` have identical encoding
+ --> tests/derive_compile_fails/two_variants_same_name.rs:4:5
+  |
+4 |     Dev {
+  |     ^^^ evaluation of `_::has_unique_encoding` failed here
+
+error[E0080]: evaluation panicked: variants `Dev` and `Cryptographer` have identical encoding
+  --> tests/derive_compile_fails/two_variants_same_name.rs:19:5
+   |
+19 |     Dev {
+   |     ^^^ evaluation of `_::has_unique_encoding` failed here
+
+error[E0080]: evaluation panicked: variants `Dev` and `Cryptographer` have identical encoding
+  --> tests/derive_compile_fails/two_variants_same_name.rs:35:5
+   |
+35 |     Dev {
+   |     ^^^ evaluation of `_::has_unique_encoding` failed here
+
+error[E0080]: evaluation panicked: variants `Dev` and `Cryptographer` have identical encoding
+  --> tests/derive_compile_fails/two_variants_same_name.rs:51:5
+   |
+51 |     Dev {
+   |     ^^^ evaluation of `_::has_unique_encoding` failed here
+
+error[E0080]: evaluation panicked: variants `Dev` and `Cryptographer` have identical encoding
+  --> tests/derive_compile_fails/two_variants_same_name.rs:65:5
+   |
+65 |     Dev {
+   |     ^^^ evaluation of `_::has_unique_encoding` failed here
+
+error[E0080]: evaluation panicked: variants `Dev` and `Cryptographer` have identical encoding
+  --> tests/derive_compile_fails/two_variants_same_name.rs:81:5
+   |
+81 |     Dev {
+   |     ^^^ evaluation of `_::has_unique_encoding` failed here

--- a/udigest/tests/derive_encoding.rs
+++ b/udigest/tests/derive_encoding.rs
@@ -1,0 +1,185 @@
+//! In this test, we use proc macro with all possible attributes combinations to implement
+//! `Digestable` trait, and then assert that encoding is as expected
+//!
+//! This test ensures that encoding stays compatible between versions of `udigest`. If
+//! any of those tests break, it likely indicates a breaking change in the encoding.
+
+mod common;
+
+#[derive(udigest::Digestable)]
+enum Shape {
+    Circle {
+        r: u16,
+        color: Color,
+    },
+    #[udigest(rename = "Rectangular")]
+    Rect {
+        w: u16,
+        h: u16,
+        #[udigest(skip)]
+        surface: u32,
+        #[udigest(with = funny_color_encoding)]
+        color: Color,
+    },
+    Square {
+        #[udigest(rename = "width")]
+        #[udigest(as = LittleEndian)]
+        w: u16,
+        #[udigest(as_bytes)]
+        color: [u8; 3],
+    },
+    Generic {
+        name: String,
+        #[udigest(as_bytes = Wrapper::as_bytes)]
+        wrapper: Wrapper,
+        points: Vec<(u8, u8)>,
+    },
+}
+
+#[derive(udigest::Digestable)]
+#[udigest(tag = "regular color")]
+struct Color {
+    r: u16,
+    g: u16,
+    b: u16,
+}
+
+fn funny_color_encoding<B: udigest::Buffer>(
+    color: &Color,
+    encoder: udigest::encoding::EncodeValue<B>,
+) {
+    let mut list = encoder.encode_list().with_tag(b"funny color");
+    list.add_leaf().chain(color.b.to_be_bytes());
+    list.add_leaf().chain(color.g.to_be_bytes());
+    list.add_leaf().chain(color.r.to_be_bytes());
+    list.finish();
+}
+
+struct LittleEndian;
+
+impl udigest::as_::DigestAs<u16> for LittleEndian {
+    fn digest_as<B: udigest::Buffer>(value: &u16, encoder: udigest::encoding::EncodeValue<B>) {
+        encoder.encode_leaf_value(value.to_le_bytes());
+    }
+}
+
+struct Wrapper(Vec<u8>);
+
+impl Wrapper {
+    fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+#[test]
+fn shape_circle() {
+    // This test ensures that encoding stays compatible between versions of `udigest`. If
+    // any of those tests break, it likely indicates a breaking change in the encoding.
+
+    let circle = Shape::Circle {
+        r: 10,
+        color: Color {
+            r: 12,
+            g: 13,
+            b: 14,
+        },
+    };
+    let actual = common::encode_to_vec(&circle);
+
+    let mut expected = common::VecBuf::default();
+    let mut s = udigest::encoding::EncodeValue::new(&mut expected)
+        .encode_enum()
+        .with_variant("Circle");
+    s.add_field("r").encode(&10_u8);
+    let mut color = s
+        .add_field("color")
+        .encode_struct()
+        .with_tag(b"regular color");
+    color.add_field("r").encode(&12_u16);
+    color.add_field("g").encode(&13_u16);
+    color.add_field("b").encode(&14_u16);
+    color.finish();
+    s.finish();
+
+    assert_eq!(hex::encode(actual), hex::encode(expected.0));
+}
+
+#[test]
+fn shape_rect() {
+    // This test ensures that encoding stays compatible between versions of `udigest`. If
+    // any of those tests break, it likely indicates a breaking change in the encoding.
+
+    let rect = Shape::Rect {
+        w: 10,
+        h: 11,
+        surface: 10 * 11,
+        color: Color {
+            r: 100,
+            g: 101,
+            b: 102,
+        },
+    };
+    let actual = common::encode_to_vec(&rect);
+
+    let mut expected = common::VecBuf::default();
+    let mut s = udigest::encoding::EncodeValue::new(&mut expected)
+        .encode_enum()
+        .with_variant("Rectangular");
+    s.add_field("w").encode(&10_u16);
+    s.add_field("h").encode(&11_u16);
+    let mut color = s.add_field("color").encode_list().with_tag(b"funny color");
+    color.add_leaf().chain(102_u16.to_be_bytes());
+    color.add_leaf().chain(101_u16.to_be_bytes());
+    color.add_leaf().chain(100_u16.to_be_bytes());
+    color.finish();
+    s.finish();
+
+    assert_eq!(hex::encode(actual), hex::encode(expected.0));
+}
+
+#[test]
+fn shape_square() {
+    // This test ensures that encoding stays compatible between versions of `udigest`. If
+    // any of those tests break, it likely indicates a breaking change in the encoding.
+
+    let square = Shape::Square {
+        w: 1001,
+        color: [1, 2, 3],
+    };
+    let actual = common::encode_to_vec(&square);
+
+    let mut expected = common::VecBuf::default();
+    let mut s = udigest::encoding::EncodeValue::new(&mut expected)
+        .encode_enum()
+        .with_variant("Square");
+    s.add_field("width")
+        .encode_leaf_value(1001_u16.to_le_bytes());
+    s.add_field("color").encode_leaf_value([1, 2, 3]);
+    s.finish();
+
+    assert_eq!(hex::encode(actual), hex::encode(expected.0));
+}
+
+#[test]
+fn shape_generic() {
+    // This test ensures that encoding stays compatible between versions of `udigest`. If
+    // any of those tests break, it likely indicates a breaking change in the encoding.
+
+    let shape = Shape::Generic {
+        name: "triangle".to_owned(),
+        wrapper: Wrapper(vec![10, 11, 100]),
+        points: vec![(0, 0), (1, 0), (0, 1)],
+    };
+    let actual = common::encode_to_vec(&shape);
+
+    let mut expected = common::VecBuf::default();
+    let mut s = udigest::encoding::EncodeValue::new(&mut expected)
+        .encode_enum()
+        .with_variant("Generic");
+    s.add_field("name").encode_leaf_value("triangle");
+    s.add_field("wrapper").encode_leaf_value([10, 11, 100]);
+    s.add_field("points").encode(&[(0u8, 0u8), (1, 0), (0, 1)]);
+    s.finish();
+
+    assert_eq!(hex::encode(actual), hex::encode(expected.0));
+}


### PR DESCRIPTION
Fixes #21.

https://github.com/LFDT-Lockness/udigest/blob/96587dad2fcce65ac5580932955f5b3348511e28/udigest/CHANGELOG.md?plain=1#L1-L52

PR can be reviewed commit-by-commit.

<s>TODO: I realized that it's worth adding miri tests to make sure there's no UB with introducing unsafe code. I will do that shortly, but rest of PR can be already reviewed.</s> miri tests are added