### PR TITLE
Make `Digestable` trait `dyn`-compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "udigest"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "blake2",
  "digest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "udigest"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "blake2",
  "digest",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "udigest-derive"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/udigest-derive/CHANGELOG.md
+++ b/udigest-derive/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.5.0
+* Sync the derive macro with latest changes in `udigest` library [#25]
+
+[#25]: https://github.com/LFDT-Lockness/udigest/pull/25
+
 ## v0.4.0
 * `rename` attribute now works on enum variants as it always should have been
 * Derive macro produces an error if two fields or two enum variants have the same

--- a/udigest-derive/Cargo.toml
+++ b/udigest-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udigest-derive"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 description = "Proc macro for `udigest` crate"
 license = "MIT OR Apache-2.0"

--- a/udigest-derive/src/lib.rs
+++ b/udigest-derive/src/lib.rs
@@ -495,9 +495,7 @@ fn generate_impl_for_enum(
 
     Ok(quote! {
         impl #impl_generics #root_path::Digestable for #enum_name #ty_generics #where_clause {
-            fn unambiguously_encode<B>(&self, encoder: #root_path::encoding::EncodeValue<B>)
-            where
-                B: #root_path::Buffer
+            fn unambiguously_encode(&self, encoder: #root_path::encoding::EncodeValue)
             {
                 let mut #encoder_var = encoder.encode_enum();
                 #specify_tag
@@ -549,9 +547,7 @@ fn generate_impl_for_struct(
 
     Ok(quote! {
         impl #impl_generics #root_path::Digestable for #struct_name #ty_generics #where_clause {
-            fn unambiguously_encode<B>(&self, encoder: #root_path::encoding::EncodeValue<B>)
-            where
-                B: #root_path::Buffer
+            fn unambiguously_encode(&self, encoder: #root_path::encoding::EncodeValue)
             {
                 let mut #encoder_var = encoder.encode_struct();
                 #specify_tag

--- a/udigest/CHANGELOG.md
+++ b/udigest/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.4.0
+* Make `Digestable` trait `dyn`-compatible [#25]
+* Update hash functions to accept `&dyn Digestable` [#25]
+
+[#25]: https://github.com/LFDT-Lockness/udigest/pull/25
+
 ## v0.3.1
 * Fix docs.rs build [#24]
 

--- a/udigest/Cargo.toml
+++ b/udigest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udigest"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 license = "MIT OR Apache-2.0"
 description = "Unambiguously digest structured data"
@@ -18,7 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 digest = { version = "0.10", default-features = false, optional = true }
 
-udigest-derive = { version = "=0.4.0", path = "../udigest-derive", optional = true }
+udigest-derive = { version = "=0.5.0", path = "../udigest-derive", optional = true }
 
 [dev-dependencies]
 hex = "0.4"

--- a/udigest/Cargo.toml
+++ b/udigest/Cargo.toml
@@ -56,6 +56,10 @@ name = "deterministic_hash"
 required-features = ["derive", "digest"]
 
 [[test]]
+name = "diff_structs_same_encoding"
+required-features = ["derive", "digest"]
+
+[[test]]
 name = "inline_struct"
 required-features = ["derive", "inline-struct"]
 

--- a/udigest/src/as_.rs
+++ b/udigest/src/as_.rs
@@ -12,12 +12,12 @@
 //!
 //! See more examples in [macro@Digestable] macro docs.
 
-use crate::{Buffer, Digestable, encoding};
+use crate::{Digestable, encoding};
 
 /// Custom rule for digesting an instance of `T`
 pub trait DigestAs<T: ?Sized> {
     /// Digests `value`
-    fn digest_as<B: Buffer>(value: &T, encoder: encoding::EncodeValue<B>);
+    fn digest_as(value: &T, encoder: encoding::EncodeValue);
 }
 
 impl<T, U> DigestAs<&T> for &U
@@ -25,7 +25,7 @@ where
     T: ?Sized,
     U: DigestAs<T> + ?Sized,
 {
-    fn digest_as<B: Buffer>(value: &&T, encoder: encoding::EncodeValue<B>) {
+    fn digest_as(value: &&T, encoder: encoding::EncodeValue) {
         U::digest_as(*value, encoder)
     }
 }
@@ -55,7 +55,7 @@ impl<T, U> Digestable for As<T, U>
 where
     U: DigestAs<T>,
 {
-    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+    fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
         U::digest_as(&self.value, encoder)
     }
 }
@@ -84,7 +84,7 @@ impl<T> DigestAs<T> for Same
 where
     T: Digestable + ?Sized,
 {
-    fn digest_as<B: Buffer>(value: &T, encoder: encoding::EncodeValue<B>) {
+    fn digest_as(value: &T, encoder: encoding::EncodeValue) {
         value.unambiguously_encode(encoder)
     }
 }
@@ -95,7 +95,7 @@ impl<T> DigestAs<T> for Bytes
 where
     T: AsRef<[u8]> + ?Sized,
 {
-    fn digest_as<B: Buffer>(value: &T, encoder: encoding::EncodeValue<B>) {
+    fn digest_as(value: &T, encoder: encoding::EncodeValue) {
         encoder.encode_leaf_value(value.as_ref())
     }
 }
@@ -104,7 +104,7 @@ impl<T, U> DigestAs<Option<T>> for Option<U>
 where
     U: DigestAs<T>,
 {
-    fn digest_as<B: Buffer>(value: &Option<T>, encoder: encoding::EncodeValue<B>) {
+    fn digest_as(value: &Option<T>, encoder: encoding::EncodeValue) {
         value
             .as_ref()
             .map(As::<&T, &U>::new)
@@ -117,7 +117,7 @@ where
     TAs: DigestAs<T>,
     EAs: DigestAs<E>,
 {
-    fn digest_as<B: Buffer>(value: &Result<T, E>, encoder: encoding::EncodeValue<B>) {
+    fn digest_as(value: &Result<T, E>, encoder: encoding::EncodeValue) {
         value
             .as_ref()
             .map(As::<&T, &TAs>::new)
@@ -130,7 +130,7 @@ impl<T, U> DigestAs<[T]> for [U]
 where
     U: DigestAs<T>,
 {
-    fn digest_as<B: Buffer>(value: &[T], encoder: encoding::EncodeValue<B>) {
+    fn digest_as(value: &[T], encoder: encoding::EncodeValue) {
         crate::unambiguously_encode_iter(encoder, value.iter().map(As::<&T, &U>::new))
     }
 }
@@ -139,7 +139,7 @@ impl<T, U, const N: usize> DigestAs<[T; N]> for [U; N]
 where
     U: DigestAs<T>,
 {
-    fn digest_as<B: Buffer>(value: &[T; N], encoder: encoding::EncodeValue<B>) {
+    fn digest_as(value: &[T; N], encoder: encoding::EncodeValue) {
         crate::unambiguously_encode_iter(encoder, value.iter().map(As::<&T, &U>::new))
     }
 }
@@ -149,7 +149,7 @@ impl<T, U> DigestAs<alloc::vec::Vec<T>> for alloc::vec::Vec<U>
 where
     U: DigestAs<T>,
 {
-    fn digest_as<B: Buffer>(value: &alloc::vec::Vec<T>, encoder: encoding::EncodeValue<B>) {
+    fn digest_as(value: &alloc::vec::Vec<T>, encoder: encoding::EncodeValue) {
         crate::unambiguously_encode_iter(encoder, value.iter().map(As::<&T, &U>::new))
     }
 }
@@ -158,10 +158,7 @@ impl<T, U> DigestAs<alloc::collections::LinkedList<T>> for alloc::collections::L
 where
     U: DigestAs<T>,
 {
-    fn digest_as<B: Buffer>(
-        value: &alloc::collections::LinkedList<T>,
-        encoder: encoding::EncodeValue<B>,
-    ) {
+    fn digest_as(value: &alloc::collections::LinkedList<T>, encoder: encoding::EncodeValue) {
         crate::unambiguously_encode_iter(encoder, value.iter().map(As::<&T, &U>::new))
     }
 }
@@ -170,10 +167,7 @@ impl<T, U> DigestAs<alloc::collections::VecDeque<T>> for alloc::collections::Vec
 where
     U: DigestAs<T>,
 {
-    fn digest_as<B: Buffer>(
-        value: &alloc::collections::VecDeque<T>,
-        encoder: encoding::EncodeValue<B>,
-    ) {
+    fn digest_as(value: &alloc::collections::VecDeque<T>, encoder: encoding::EncodeValue) {
         crate::unambiguously_encode_iter(encoder, value.iter().map(As::<&T, &U>::new))
     }
 }
@@ -182,10 +176,7 @@ impl<T, U> DigestAs<alloc::collections::BTreeSet<T>> for alloc::collections::BTr
 where
     U: DigestAs<T>,
 {
-    fn digest_as<B: Buffer>(
-        value: &alloc::collections::BTreeSet<T>,
-        encoder: encoding::EncodeValue<B>,
-    ) {
+    fn digest_as(value: &alloc::collections::BTreeSet<T>, encoder: encoding::EncodeValue) {
         crate::unambiguously_encode_iter(encoder, value.iter().map(As::<&T, &U>::new))
     }
 }
@@ -197,10 +188,7 @@ where
     KAs: DigestAs<K>,
     VAs: DigestAs<V>,
 {
-    fn digest_as<B: Buffer>(
-        value: &alloc::collections::BTreeMap<K, V>,
-        encoder: encoding::EncodeValue<B>,
-    ) {
+    fn digest_as(value: &alloc::collections::BTreeMap<K, V>, encoder: encoding::EncodeValue) {
         crate::unambiguously_encode_iter(
             encoder,
             value
@@ -217,10 +205,7 @@ where
     U: DigestAs<T>,
     T: core::cmp::Ord,
 {
-    fn digest_as<B: Buffer>(
-        value: &std::collections::HashSet<T>,
-        encoder: encoding::EncodeValue<B>,
-    ) {
+    fn digest_as(value: &std::collections::HashSet<T>, encoder: encoding::EncodeValue) {
         let ordered_map = value
             .iter()
             .map(As::<&T, &U>::new)
@@ -240,10 +225,7 @@ where
     VAs: DigestAs<V>,
     K: core::cmp::Ord,
 {
-    fn digest_as<B: Buffer>(
-        value: &std::collections::HashMap<K, V>,
-        encoder: encoding::EncodeValue<B>,
-    ) {
+    fn digest_as(value: &std::collections::HashMap<K, V>, encoder: encoding::EncodeValue) {
         let ordered_map = value
             .iter()
             .map(|(key, value)| (As::<&K, &KAs>::new(key), As::<&V, &VAs>::new(value)))
@@ -260,7 +242,7 @@ where
     U: DigestAs<T> + ?Sized,
     T: ?Sized,
 {
-    fn digest_as<B: Buffer>(value: &alloc::boxed::Box<T>, encoder: encoding::EncodeValue<B>) {
+    fn digest_as(value: &alloc::boxed::Box<T>, encoder: encoding::EncodeValue) {
         U::digest_as(value, encoder)
     }
 }
@@ -271,7 +253,7 @@ where
     U: DigestAs<T> + ?Sized,
     T: ?Sized,
 {
-    fn digest_as<B: Buffer>(value: &alloc::rc::Rc<T>, encoder: encoding::EncodeValue<B>) {
+    fn digest_as(value: &alloc::rc::Rc<T>, encoder: encoding::EncodeValue) {
         U::digest_as(value, encoder)
     }
 }
@@ -282,7 +264,7 @@ where
     U: DigestAs<T> + ?Sized,
     T: ?Sized,
 {
-    fn digest_as<B: Buffer>(value: &alloc::sync::Arc<T>, encoder: encoding::EncodeValue<B>) {
+    fn digest_as(value: &alloc::sync::Arc<T>, encoder: encoding::EncodeValue) {
         U::digest_as(value, encoder)
     }
 }
@@ -293,7 +275,7 @@ where
     U: DigestAs<T> + alloc::borrow::ToOwned + ?Sized,
     T: alloc::borrow::ToOwned + ?Sized + 'a,
 {
-    fn digest_as<B: Buffer>(value: &alloc::borrow::Cow<'a, T>, encoder: encoding::EncodeValue<B>) {
+    fn digest_as(value: &alloc::borrow::Cow<'a, T>, encoder: encoding::EncodeValue) {
         U::digest_as(value.as_ref(), encoder)
     }
 }
@@ -304,7 +286,7 @@ where
     U: DigestAs<T> + ?Sized,
     T: alloc::borrow::ToOwned + ?Sized + 'a,
 {
-    fn digest_as<B: Buffer>(value: &alloc::borrow::Cow<'a, T>, encoder: encoding::EncodeValue<B>) {
+    fn digest_as(value: &alloc::borrow::Cow<'a, T>, encoder: encoding::EncodeValue) {
         U::digest_as(value.as_ref(), encoder)
     }
 }
@@ -315,7 +297,7 @@ macro_rules! impl_for_tuples {
         where
             $($as: DigestAs<$t>),*
         {
-            fn digest_as<Buf: Buffer>(value: &($($t,)*), encoder: encoding::EncodeValue<Buf>) {
+            fn digest_as(value: &($($t,)*), encoder: encoding::EncodeValue) {
                 #[allow(non_snake_case)]
                 let ($($t,)*) = value;
                 (

--- a/udigest/src/encoding.rs
+++ b/udigest/src/encoding.rs
@@ -220,28 +220,53 @@ impl<D: digest::Update> Buffer for BufferUpdate<D> {
 ///
 /// Can be used to encode (only) a single value. Value can be a leaf (bytestring) or a list of values.
 #[must_use = "encoder must be used to encode a value"]
-pub struct EncodeValue<'b, B: Buffer> {
-    buffer: Option<&'b mut B>,
+pub struct EncodeValue<'buf, 'tag> {
+    buffer: Option<&'buf mut dyn Buffer>,
+    tag: Option<&'tag [u8]>,
 }
 
-impl<'b, B: Buffer> EncodeValue<'b, B> {
+impl<'buf, 'tag> EncodeValue<'buf, 'tag> {
     /// Constructs an encoder
-    pub fn new(buffer: &'b mut B) -> Self {
+    pub fn new(buffer: &'buf mut dyn Buffer) -> Self {
         Self {
             buffer: Some(buffer),
+            tag: None,
         }
     }
 
+    /// Specifies a domain separation tag
+    ///
+    /// Tag will be unambiguously encoded
+    pub fn set_tag(&mut self, tag: &'tag [u8]) {
+        self.tag = Some(tag);
+    }
+
+    /// Specifies a domain separation tag
+    ///
+    /// Tag will be unambiguously encoded
+    pub fn with_tag(mut self, tag: &'tag [u8]) -> Self {
+        self.set_tag(tag);
+        self
+    }
+
     /// Encodes a list
-    pub fn encode_list(mut self) -> EncodeList<'b, B> {
+    pub fn encode_list(mut self) -> EncodeList<'buf, 'tag> {
         #[allow(clippy::expect_used)]
-        EncodeList::new(self.buffer.take().expect("buffer must be available"))
+        let mut encoder = EncodeList::new(self.buffer.take().expect("buffer must be available"));
+        if let Some(tag) = self.tag {
+            encoder.set_tag(tag);
+        }
+        encoder
     }
 
     /// Encodes a leaf (bytestring)
-    pub fn encode_leaf(mut self) -> EncodeLeaf<'b, B> {
+    pub fn encode_leaf(mut self) -> EncodeLeaf<'buf, 'tag> {
         #[allow(clippy::expect_used)]
-        EncodeLeaf::new(self.buffer.take().expect("buffer must be available"))
+        let mut encoder = EncodeLeaf::new(self.buffer.take().expect("buffer must be available"));
+        if let Some(tag) = self.tag {
+            encoder.set_tag(tag);
+        }
+        encoder
     }
 
     /// Encodes a leaf value
@@ -254,17 +279,25 @@ impl<'b, B: Buffer> EncodeValue<'b, B> {
     /// Encodes a struct
     ///
     /// Struct is represented as a list: `[field_name1, field_value1, ...]`
-    pub fn encode_struct(mut self) -> EncodeStruct<'b, B> {
+    pub fn encode_struct(mut self) -> EncodeStruct<'buf, 'tag> {
         #[allow(clippy::expect_used)]
-        EncodeStruct::new(self.buffer.take().expect("buffer must be available"))
+        let mut encoder = EncodeStruct::new(self.buffer.take().expect("buffer must be available"));
+        if let Some(tag) = self.tag {
+            encoder.set_tag(tag);
+        }
+        encoder
     }
 
     /// Encodes an enum
     ///
     /// Enum is represented as a list: `["variant", variant_name, field_name1, field_value1, ...]`
-    pub fn encode_enum(mut self) -> EncodeEnum<'b, B> {
+    pub fn encode_enum(mut self) -> EncodeEnum<'buf, 'tag> {
         #[allow(clippy::expect_used)]
-        EncodeEnum::new(self.buffer.take().expect("buffer must be available"))
+        let mut encoder = EncodeEnum::new(self.buffer.take().expect("buffer must be available"));
+        if let Some(tag) = self.tag {
+            encoder.set_tag(tag);
+        }
+        encoder
     }
 
     /// Encodes a value that implements [`Digestable`](crate::Digestable) trait
@@ -275,7 +308,7 @@ impl<'b, B: Buffer> EncodeValue<'b, B> {
     }
 }
 
-impl<'b, B: Buffer> Drop for EncodeValue<'b, B> {
+impl<'buf, 'tag> Drop for EncodeValue<'buf, 'tag> {
     fn drop(&mut self) {
         if let Some(buffer) = &mut self.buffer {
             // buffer is not consumed -- we write an empty leaf
@@ -289,21 +322,21 @@ impl<'b, B: Buffer> Drop for EncodeValue<'b, B> {
 /// Enum variant is encoded as a list: `["variant", variant_name]`. If variant contains any fields,
 /// they are encoded in the same way as [structure](EncodeStruct) fields are encoded.
 #[must_use = "encoder must be used to encode a value"]
-pub struct EncodeEnum<'b, B: Buffer> {
-    buffer: &'b mut B,
-    tag: Option<&'b [u8]>,
+pub struct EncodeEnum<'buf, 'tag> {
+    buffer: &'buf mut dyn Buffer,
+    tag: Option<&'tag [u8]>,
 }
 
-impl<'b, B: Buffer> EncodeEnum<'b, B> {
+impl<'buf, 'tag> EncodeEnum<'buf, 'tag> {
     /// Constructs an encoder
-    pub fn new(buffer: &'b mut B) -> Self {
+    pub fn new(buffer: &'buf mut dyn Buffer) -> Self {
         Self { buffer, tag: None }
     }
 
     /// Encodes a variant name
     ///
     /// Returns a structure encoder that can be used to encode any fields the variant may have
-    pub fn with_variant(self, variant_name: impl AsRef<[u8]>) -> EncodeStruct<'b, B> {
+    pub fn with_variant(self, variant_name: impl AsRef<[u8]>) -> EncodeStruct<'buf, 'tag> {
         let mut s = EncodeStruct::new(self.buffer);
         s.add_field("variant").encode_leaf().chain(variant_name);
         if let Some(tag) = self.tag {
@@ -315,27 +348,27 @@ impl<'b, B: Buffer> EncodeEnum<'b, B> {
     /// Specifies a domain separation tag
     ///
     /// Tag will be unambiguously encoded
-    pub fn set_tag(&mut self, tag: &'b [u8]) {
+    pub fn set_tag(&mut self, tag: &'tag [u8]) {
         self.tag = Some(tag);
     }
 
     /// Specifies a domain separation tag
     ///
     /// Tag will be unambiguously encoded
-    pub fn with_tag(mut self, tag: &'b [u8]) -> Self {
+    pub fn with_tag(mut self, tag: &'tag [u8]) -> Self {
         self.set_tag(tag);
         self
     }
 }
 
 /// Encodes a structure
-pub struct EncodeStruct<'b, B: Buffer> {
-    list: EncodeList<'b, B>,
+pub struct EncodeStruct<'buf, 'tag> {
+    list: EncodeList<'buf, 'tag>,
 }
 
-impl<'b, B: Buffer> EncodeStruct<'b, B> {
+impl<'buf, 'tag> EncodeStruct<'buf, 'tag> {
     /// Constructs an encoder
-    pub fn new(buffer: &'b mut B) -> Self {
+    pub fn new(buffer: &'buf mut dyn Buffer) -> Self {
         Self {
             list: EncodeList::new(buffer),
         }
@@ -344,14 +377,14 @@ impl<'b, B: Buffer> EncodeStruct<'b, B> {
     /// Specifies a domain separation tag
     ///
     /// Tag will be unambiguously encoded
-    pub fn set_tag(&mut self, tag: &'b [u8]) {
+    pub fn set_tag(&mut self, tag: &'tag [u8]) {
         self.list.set_tag(tag);
     }
 
     /// Specifies a domain separation tag
     ///
     /// Tag will be unambiguously encoded
-    pub fn with_tag(mut self, tag: &'b [u8]) -> Self {
+    pub fn with_tag(mut self, tag: &'tag [u8]) -> Self {
         self.set_tag(tag);
         self
     }
@@ -359,7 +392,7 @@ impl<'b, B: Buffer> EncodeStruct<'b, B> {
     /// Adds a fields to the structure
     ///
     /// Returns an encoder that shall be used to encode the fields value
-    pub fn add_field(&mut self, field_name: impl AsRef<[u8]>) -> EncodeValue<'_, B> {
+    pub fn add_field<'t>(&mut self, field_name: impl AsRef<[u8]>) -> EncodeValue<'_, 't> {
         self.list.add_leaf().chain(field_name);
         self.list.add_item()
     }
@@ -371,15 +404,15 @@ impl<'b, B: Buffer> EncodeStruct<'b, B> {
 }
 
 /// Encodes a leaf (bytestring)
-pub struct EncodeLeaf<'b, B: Buffer> {
-    buffer: &'b mut B,
+pub struct EncodeLeaf<'buf, 'tag> {
+    buffer: &'buf mut dyn Buffer,
     len: usize,
-    tag: Option<&'b [u8]>,
+    tag: Option<&'tag [u8]>,
 }
 
-impl<'b, B: Buffer> EncodeLeaf<'b, B> {
+impl<'buf, 'tag> EncodeLeaf<'buf, 'tag> {
     /// Constructs a leaf
-    pub fn new(buffer: &'b mut B) -> Self {
+    pub fn new(buffer: &'buf mut dyn Buffer) -> Self {
         Self {
             buffer,
             len: 0,
@@ -390,14 +423,14 @@ impl<'b, B: Buffer> EncodeLeaf<'b, B> {
     /// Specifies a domain separation tag
     ///
     /// Tag will be unambiguously encoded
-    pub fn set_tag(&mut self, tag: &'b [u8]) {
+    pub fn set_tag(&mut self, tag: &'tag [u8]) {
         self.tag = Some(tag)
     }
 
     /// Specifies a domain separation tag
     ///
     /// Tag will be unambiguously encoded
-    pub fn with_tag(mut self, tag: &'b [u8]) -> Self {
+    pub fn with_tag(mut self, tag: &'tag [u8]) -> Self {
         self.set_tag(tag);
         self
     }
@@ -432,7 +465,7 @@ impl<'b, B: Buffer> EncodeLeaf<'b, B> {
     pub fn finish(self) {}
 }
 
-impl<'b, B: Buffer> Drop for EncodeLeaf<'b, B> {
+impl<'buf, 'tag> Drop for EncodeLeaf<'buf, 'tag> {
     fn drop(&mut self) {
         encode_len(self.buffer, self.len);
 
@@ -448,15 +481,15 @@ impl<'b, B: Buffer> Drop for EncodeLeaf<'b, B> {
 }
 
 /// Encodes a list of values
-pub struct EncodeList<'b, B: Buffer> {
-    buffer: &'b mut B,
+pub struct EncodeList<'buf, 'tag> {
+    buffer: &'buf mut dyn Buffer,
     len: usize,
-    tag: Option<&'b [u8]>,
+    tag: Option<&'tag [u8]>,
 }
 
-impl<'b, B: Buffer> EncodeList<'b, B> {
+impl<'buf, 'tag> EncodeList<'buf, 'tag> {
     /// Constructs an encoder
-    pub fn new(buffer: &'b mut B) -> Self {
+    pub fn new(buffer: &'buf mut dyn Buffer) -> Self {
         Self {
             buffer,
             len: 0,
@@ -467,14 +500,14 @@ impl<'b, B: Buffer> EncodeList<'b, B> {
     /// Specifies a domain separation tag
     ///
     /// Tag will be unambiguously encoded
-    pub fn set_tag(&mut self, tag: &'b [u8]) {
+    pub fn set_tag(&mut self, tag: &'tag [u8]) {
         self.tag = Some(tag)
     }
 
     /// Specifies a domain separation tag
     ///
     /// Tag will be unambiguously encoded
-    pub fn with_tag(mut self, tag: &'b [u8]) -> Self {
+    pub fn with_tag(mut self, tag: &'tag [u8]) -> Self {
         self.set_tag(tag);
         self
     }
@@ -486,7 +519,7 @@ impl<'b, B: Buffer> EncodeList<'b, B> {
     /// ## Panic
     /// Panics if list length overflows `usize`
     #[allow(clippy::expect_used)]
-    pub fn add_item(&mut self) -> EncodeValue<'_, B> {
+    pub fn add_item<'t>(&mut self) -> EncodeValue<'_, 't> {
         self.len = self.len.checked_add(1).expect("list len overflows usize");
         EncodeValue::new(self.buffer)
     }
@@ -494,14 +527,14 @@ impl<'b, B: Buffer> EncodeList<'b, B> {
     /// Adds a leaf (bytestring) to the list
     ///
     /// Alias to `.add_item().encode_leaf()`
-    pub fn add_leaf(&mut self) -> EncodeLeaf<'_, B> {
+    pub fn add_leaf<'t>(&mut self) -> EncodeLeaf<'_, 't> {
         self.add_item().encode_leaf()
     }
 
     /// Adds a sublist to the list
     ///
     /// Alias to `.add_item().encode_list()`
-    pub fn add_list(&mut self) -> EncodeList<'_, B> {
+    pub fn add_list(&mut self) -> EncodeList<'_, '_> {
         self.add_item().encode_list()
     }
 
@@ -511,7 +544,7 @@ impl<'b, B: Buffer> EncodeList<'b, B> {
     pub fn finish(self) {}
 }
 
-impl<'b, B: Buffer> Drop for EncodeList<'b, B> {
+impl<'buf, 'tag> Drop for EncodeList<'buf, 'tag> {
     fn drop(&mut self) {
         encode_len(self.buffer, self.len);
 
@@ -530,7 +563,7 @@ impl<'b, B: Buffer> Drop for EncodeList<'b, B> {
 ///
 /// Although we expose how the length is encoded, normally you should use [EncodeList]
 /// and [EncodeLeaf] which use this function internally
-pub fn encode_len(buffer: &mut impl Buffer, len: usize) {
+pub fn encode_len(buffer: &mut dyn Buffer, len: usize) {
     match u32::try_from(len) {
         Ok(len_32) => {
             buffer.write(&len_32.to_be_bytes());

--- a/udigest/src/inline_struct.rs
+++ b/udigest/src/inline_struct.rs
@@ -83,7 +83,7 @@ impl<'t, F: FieldsList> InlineStruct<'t, F> {
 }
 
 impl<'a, F: FieldsList> crate::Digestable for InlineStruct<'a, F> {
-    fn unambiguously_encode<B: crate::Buffer>(&self, encoder: crate::encoding::EncodeValue<B>) {
+    fn unambiguously_encode(&self, encoder: crate::encoding::EncodeValue) {
         let mut struct_encode = encoder.encode_struct();
         if let Some(tag) = self.tag {
             struct_encode.set_tag(tag);
@@ -202,7 +202,7 @@ mod sealed {
 /// Normally, you don't need to use it directly. Use [`inline_struct!`] macro instead.
 pub trait FieldsList: sealed::Sealed {
     /// Encodes all fields in order from the first to last
-    fn encode<B: crate::Buffer>(&self, encoder: &mut crate::encoding::EncodeStruct<B>);
+    fn encode(&self, encoder: &mut crate::encoding::EncodeStruct);
 }
 
 /// Empty list of fields
@@ -212,7 +212,7 @@ pub trait FieldsList: sealed::Sealed {
 pub struct Nil;
 impl sealed::Sealed for Nil {}
 impl FieldsList for Nil {
-    fn encode<B: crate::Buffer>(&self, _encoder: &mut crate::encoding::EncodeStruct<B>) {
+    fn encode(&self, _encoder: &mut crate::encoding::EncodeStruct) {
         // Empty list - do nothing
     }
 }
@@ -230,7 +230,7 @@ pub struct Cons<'a, V, T> {
 impl<'a, V, T> sealed::Sealed for Cons<'a, V, T> {}
 
 impl<'a, V: crate::Digestable, T: FieldsList> FieldsList for Cons<'a, V, T> {
-    fn encode<B: crate::Buffer>(&self, encoder: &mut crate::encoding::EncodeStruct<B>) {
+    fn encode(&self, encoder: &mut crate::encoding::EncodeStruct) {
         // Since we store fields from last to first, we need to encode the tail first
         // to reverse order of fields
         self.tail.encode(encoder);

--- a/udigest/src/lib.rs
+++ b/udigest/src/lib.rs
@@ -259,7 +259,7 @@ pub mod _macros;
 
 /// Digests a structured `value` using fixed-output hash function (like sha2-256)
 #[cfg(feature = "digest")]
-pub fn hash<D: digest::Digest>(value: &impl Digestable) -> digest::Output<D> {
+pub fn hash<D: digest::Digest>(value: &dyn Digestable) -> digest::Output<D> {
     let mut hash = encoding::BufferDigest(D::new());
     value.unambiguously_encode(encoding::EncodeValue::new(&mut hash));
     hash.0.finalize()
@@ -282,7 +282,7 @@ pub fn hash_iter<D: digest::Digest>(
 
 /// Digests a structured `value` using extendable-output hash function (like shake-256)
 #[cfg(feature = "digest")]
-pub fn hash_xof<D>(value: &impl Digestable) -> D::Reader
+pub fn hash_xof<D>(value: &dyn Digestable) -> D::Reader
 where
     D: Default + digest::Update + digest::ExtendableOutput,
 {
@@ -309,7 +309,7 @@ where
 
 /// Digests a structured `value` using variable-output hash function (like blake2b)
 #[cfg(feature = "digest")]
-pub fn hash_vof<D>(value: &impl Digestable, out: &mut [u8]) -> Result<(), digest::InvalidOutputSize>
+pub fn hash_vof<D>(value: &dyn Digestable, out: &mut [u8]) -> Result<(), digest::InvalidOutputSize>
 where
     D: digest::VariableOutput + digest::Update,
 {

--- a/udigest/src/lib.rs
+++ b/udigest/src/lib.rs
@@ -167,9 +167,7 @@ pub use encoding::Buffer;
 ///   Can be used to override the field encoding. Accepts as input a function with a signature:
 ///   ```rust,no_run
 ///   # type T = String;
-///   fn encoder<B>(value: &T, encoder: udigest::encoding::EncodeValue<B>)
-///   where
-///       B: udigest::Buffer
+///   fn encoder(value: &T, encoder: udigest::encoding::EncodeValue)
 ///   # {}
 ///   ```
 ///   Example:
@@ -182,9 +180,9 @@ pub use encoding::Buffer;
 ///       #[udigest(with = encode_instant)]
 ///       created_at: std::time::Instant,
 ///   }
-///   fn encode_instant<B: udigest::Buffer>(
+///   fn encode_instant(
 ///       instant: &std::time::Instant,
-///       encoder: udigest::encoding::EncodeValue<B>
+///       encoder: udigest::encoding::EncodeValue
 ///   ) {
 ///       todo!()
 ///   }
@@ -346,17 +344,17 @@ where
 /// A value that can be unambiguously digested
 pub trait Digestable {
     /// Unambiguously encodes the value
-    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>);
+    fn unambiguously_encode(&self, encoder: encoding::EncodeValue);
 }
 
 impl<T: Digestable + ?Sized> Digestable for &T {
-    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+    fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
         (*self).unambiguously_encode(encoder)
     }
 }
 
 impl Digestable for core::convert::Infallible {
-    fn unambiguously_encode<B: Buffer>(&self, _encoder: encoding::EncodeValue<B>) {
+    fn unambiguously_encode(&self, _encoder: encoding::EncodeValue) {
         match *self {}
     }
 }
@@ -367,7 +365,7 @@ impl Digestable for core::convert::Infallible {
 pub struct Bytes<T: ?Sized = [u8; 0]>(pub T);
 
 impl<T: AsRef<[u8]> + ?Sized> Digestable for Bytes<T> {
-    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+    fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
         encoder.encode_leaf_value(self.0.as_ref())
     }
 }
@@ -375,7 +373,7 @@ impl<T: AsRef<[u8]> + ?Sized> Digestable for Bytes<T> {
 macro_rules! digestable_signed_integers {
     ($($type:ty),*) => {$(
         impl Digestable for $type {
-            fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+            fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
                 encode_signed_integer(
                     self.is_positive(),
                     &self.unsigned_abs().to_be_bytes(),
@@ -387,11 +385,7 @@ macro_rules! digestable_signed_integers {
 }
 
 /// Encodes an integer without leading zeroes
-fn encode_signed_integer<B: Buffer>(
-    is_positive: bool,
-    abs_be_bytes: &[u8],
-    encoder: encoding::EncodeValue<B>,
-) {
+fn encode_signed_integer(is_positive: bool, abs_be_bytes: &[u8], encoder: encoding::EncodeValue) {
     let leading_zeroes = abs_be_bytes.iter().take_while(|b| **b == 0).count();
     let truncated_be_bytes = &abs_be_bytes[leading_zeroes..];
     if truncated_be_bytes.is_empty() {
@@ -409,7 +403,7 @@ fn encode_signed_integer<B: Buffer>(
 macro_rules! digestable_unsigned_integers {
     ($($type:ty),*) => {$(
         impl Digestable for $type {
-            fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+            fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
                 encode_unsigned_integer(&self.to_be_bytes(), encoder)
             }
         }
@@ -417,7 +411,7 @@ macro_rules! digestable_unsigned_integers {
 }
 
 /// Encodes an integer without leading zeroes
-fn encode_unsigned_integer<B: Buffer>(be_bytes: &[u8], encoder: encoding::EncodeValue<B>) {
+fn encode_unsigned_integer(be_bytes: &[u8], encoder: encoding::EncodeValue) {
     let leading_zeroes = be_bytes.iter().take_while(|b| **b == 0).count();
     let truncated_be_bytes = &be_bytes[leading_zeroes..];
     encoder.encode_leaf_value(truncated_be_bytes)
@@ -427,13 +421,13 @@ digestable_signed_integers!(i8, i16, i32, i64, i128, isize);
 digestable_unsigned_integers!(u8, u16, u32, u64, u128, usize);
 
 impl Digestable for bool {
-    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+    fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
         u8::from(*self).unambiguously_encode(encoder)
     }
 }
 
 impl Digestable for char {
-    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+    fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
         // Any char can be represented using two bytes, but strangely Rust does not provide
         // conversion into `u16`, so we convert it into `u32`
         let c: u32 = (*self).into();
@@ -445,7 +439,7 @@ impl Digestable for char {
 macro_rules! digestable_as_bytes {
     ($($type:ty as $to_bytes:ident),*) => {$(
         impl Digestable for $type {
-            fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+            fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
                 let bytes: &[u8] = self.$to_bytes();
                 encoder.encode_leaf().chain(bytes);
             }
@@ -462,7 +456,7 @@ digestable_as_bytes!(
 digestable_as_bytes!(str as as_ref, core::ffi::CStr as to_bytes);
 
 impl<T: Digestable> Digestable for Option<T> {
-    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+    fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
         match self {
             Some(value) => {
                 let mut encoder = encoder.encode_enum().with_variant("Some");
@@ -477,7 +471,7 @@ impl<T: Digestable> Digestable for Option<T> {
 }
 
 impl<T: Digestable, E: Digestable> Digestable for Result<T, E> {
-    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+    fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
         match self {
             Ok(value) => {
                 let mut encoder = encoder.encode_enum().with_variant("Ok");
@@ -496,7 +490,7 @@ impl<T: Digestable, E: Digestable> Digestable for Result<T, E> {
 macro_rules! digestable_tuple {
     ($($letter:ident),+) => {
         impl<$($letter: Digestable),+> Digestable for ($($letter,)+) {
-            fn unambiguously_encode<BUF: Buffer>(&self, encoder: encoding::EncodeValue<BUF>) {
+            fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
                 #[allow(non_snake_case)]
                 let ($($letter,)+) = self;
                 let mut list = encoder.encode_list();
@@ -527,8 +521,8 @@ digestable_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N);
 digestable_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
 digestable_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
 
-fn unambiguously_encode_iter<B: Buffer, T: Digestable>(
-    encoder: encoding::EncodeValue<B>,
+fn unambiguously_encode_iter<T: Digestable>(
+    encoder: encoding::EncodeValue,
     iter: impl IntoIterator<Item = T>,
 ) {
     let mut list = encoder.encode_list();
@@ -539,48 +533,48 @@ fn unambiguously_encode_iter<B: Buffer, T: Digestable>(
 }
 
 impl<T: Digestable> Digestable for [T] {
-    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+    fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
         unambiguously_encode_iter(encoder, self)
     }
 }
 
 impl<T: Digestable, const N: usize> Digestable for [T; N] {
-    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+    fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
         self.as_slice().unambiguously_encode(encoder)
     }
 }
 
 #[cfg(feature = "alloc")]
 impl<T: Digestable> Digestable for alloc::vec::Vec<T> {
-    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+    fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
         self.as_slice().unambiguously_encode(encoder)
     }
 }
 
 #[cfg(feature = "alloc")]
 impl<T: Digestable> Digestable for alloc::collections::LinkedList<T> {
-    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+    fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
         unambiguously_encode_iter(encoder, self)
     }
 }
 
 #[cfg(feature = "alloc")]
 impl<T: Digestable> Digestable for alloc::collections::VecDeque<T> {
-    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+    fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
         unambiguously_encode_iter(encoder, self)
     }
 }
 
 #[cfg(feature = "alloc")]
 impl<T: Digestable> Digestable for alloc::collections::BTreeSet<T> {
-    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+    fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
         unambiguously_encode_iter(encoder, self)
     }
 }
 
 #[cfg(feature = "alloc")]
 impl<K: Digestable, V: Digestable> Digestable for alloc::collections::BTreeMap<K, V> {
-    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+    fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
         unambiguously_encode_iter(encoder, self)
     }
 }
@@ -590,7 +584,7 @@ impl<K: Digestable, V: Digestable> Digestable for alloc::collections::BTreeMap<K
 macro_rules! digestable_wrapper {
     ($($wrapper:ty),*) => {$(
         impl<T: Digestable + ?Sized> Digestable for $wrapper {
-            fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+            fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
                 (&**self).unambiguously_encode(encoder)
             }
         }
@@ -605,13 +599,13 @@ impl<'a, T> Digestable for alloc::borrow::Cow<'a, T>
 where
     T: Digestable + alloc::borrow::ToOwned + ?Sized + 'a,
 {
-    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+    fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
         self.as_ref().unambiguously_encode(encoder);
     }
 }
 
 impl<T> Digestable for core::marker::PhantomData<T> {
-    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>) {
+    fn unambiguously_encode(&self, encoder: encoding::EncodeValue) {
         // Encode an empty list
         encoder.encode_list();
     }

--- a/udigest/tests/derive.rs
+++ b/udigest/tests/derive.rs
@@ -112,3 +112,12 @@ pub struct OptionalBytes {
     #[udigest(as = std::collections::BTreeMap<_, udigest::Bytes>)]
     hash_map: std::collections::HashMap<String, Vec<u8>>,
 }
+
+#[derive(udigest::Digestable)]
+pub enum EnumWithDyn<'a> {
+    ProtocolName {
+        protocol_name: &'a str,
+        version: u64,
+    },
+    Custom(&'a dyn udigest::Digestable),
+}

--- a/udigest/tests/derive.rs
+++ b/udigest/tests/derive.rs
@@ -87,10 +87,7 @@ pub struct StructAttrWith {
 pub struct Bar;
 
 mod encoding {
-    pub fn encode_bar<B: udigest::Buffer>(
-        _bar: &super::Bar,
-        encoder: udigest::encoding::EncodeValue<B>,
-    ) {
+    pub fn encode_bar(_bar: &super::Bar, encoder: udigest::encoding::EncodeValue) {
         let mut list = encoder.encode_list();
         list.add_leaf().chain("foo");
         list.add_leaf().chain("bar");

--- a/udigest/tests/derive_encoding.rs
+++ b/udigest/tests/derive_encoding.rs
@@ -44,10 +44,7 @@ struct Color {
     b: u16,
 }
 
-fn funny_color_encoding<B: udigest::Buffer>(
-    color: &Color,
-    encoder: udigest::encoding::EncodeValue<B>,
-) {
+fn funny_color_encoding(color: &Color, encoder: udigest::encoding::EncodeValue) {
     let mut list = encoder.encode_list().with_tag(b"funny color");
     list.add_leaf().chain(color.b.to_be_bytes());
     list.add_leaf().chain(color.g.to_be_bytes());
@@ -58,7 +55,7 @@ fn funny_color_encoding<B: udigest::Buffer>(
 struct LittleEndian;
 
 impl udigest::as_::DigestAs<u16> for LittleEndian {
-    fn digest_as<B: udigest::Buffer>(value: &u16, encoder: udigest::encoding::EncodeValue<B>) {
+    fn digest_as(value: &u16, encoder: udigest::encoding::EncodeValue) {
         encoder.encode_leaf_value(value.to_le_bytes());
     }
 }

--- a/udigest/tests/diff_structs_same_encoding.rs
+++ b/udigest/tests/diff_structs_same_encoding.rs
@@ -1,0 +1,46 @@
+#[derive(udigest::Digestable)]
+struct BlogPost {
+    title: String,
+    content: String,
+}
+
+#[derive(udigest::Digestable)]
+struct Issue {
+    title: String,
+    content: String,
+}
+
+#[derive(udigest::Digestable)]
+#[udigest(tag = "dfns.udigest.example.issue_with_tag.v1")]
+struct IssueWithTag {
+    title: String,
+    content: String,
+}
+
+#[test]
+fn hash_the_same() {
+    let title = "Ambiguous Encoding Bug";
+    let content = "Using ambiguous encoding enables malicious payload manipulation under the exact same hash.";
+
+    let blog_post = BlogPost {
+        title: title.to_owned(),
+        content: content.to_owned(),
+    };
+    let issue = Issue {
+        title: title.to_owned(),
+        content: content.to_owned(),
+    };
+
+    // Hash is the same even though the structures are different as they have the same encoding
+    let hash1 = udigest::hash::<sha2::Sha256>(&blog_post);
+    let hash2 = udigest::hash::<sha2::Sha256>(&issue);
+    assert_eq!(hex::encode(hash1), hex::encode(hash2));
+
+    // Use a unique domain separation tag to avoid ambiguity
+    let issue_with_tag = IssueWithTag {
+        title: title.to_owned(),
+        content: content.to_owned(),
+    };
+    let hash3 = udigest::hash::<sha2::Sha256>(&issue_with_tag);
+    assert_ne!(hex::encode(hash1), hex::encode(hash3));
+}


### PR DESCRIPTION
This PR removes generics from some methods and replaces them with `dyn` objects, e.g.:

```rust
pub trait Digestable {
    // before
    fn unambiguously_encode<B: Buffer>(&self, encoder: encoding::EncodeValue<B>);
    // now
    fn unambiguously_encode(&self, encoder: encoding::EncodeValue); // `encoder` stores `&dyn Buffer`
}
```

This makes the trait `dyn`-compatible. My main motivation is to be able to write something like this:

```rust
#[derive(udigest::Digestable)]
enum SharedState<'a> {
    ProtocolName {
        protocol_name: &'a str,
        version: u64,
    },
    Custom(&'a dyn udigest::Digestable),
}
```

Besides, this optimizes the size of the final binary. Previously, each invocation of `udigest::hash` basically duplicated the whole udigest library per each used hash function and per each type of hashed object. Using `dyn` object removes most of the duplications.